### PR TITLE
remove pyEQL.unit deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking** `pyEQL.unit` deprecation machinery has been removed to quiet the warning
+  messages on import. The `pyEQL` unit registry was renamed to `pyEQL.ureg` in v0.6.1.
 - Significant documentation updates.
 - `Solution.components` is now automatically sorted in descending order of amount, for
   consistency with `anions`, `cations`, and `neutrals`.

--- a/src/pyEQL/__init__.py
+++ b/src/pyEQL/__init__.py
@@ -10,7 +10,6 @@ and performing chemical thermodynamics computations.
 """
 from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 
-from monty.dev import deprecated
 from pint import UnitRegistry
 from pkg_resources import resource_filename
 
@@ -40,16 +39,6 @@ ureg.enable_contexts("chem")
 # set the default string formatting for pint quantities
 ureg.default_format = "P~"
 
-
-# deprecation machinery to transition from unit to ureg
-@deprecated(
-    message="The pyEQL UnitRegistry has been renamed from unit to ureg. Change 'from pyEQL import unit' to 'from pyEQL import ureg'!"
-)
-def unitdeprecator():
-    return ureg
-
-
-globals()["unit"] = unitdeprecator()
 
 from pyEQL.functions import *  # noqa: E402, F403
 from pyEQL.solution import Solution  # noqa: E402


### PR DESCRIPTION
Removes the machinery to automatically redirect `pyEQL.unit` to `pyEQL.ureg`. This caused a noisy warning anytime pyEQL was imported. The rename happened in v0.6.1.