### PR TITLE
Add utility method to format dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `format_solutes_dict()` method added into the utils module to help format solutes dictionaries with a unit.
+
 ## [0.9.0] - 2023-10-17
 
 ### Added

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -40,21 +40,18 @@ def format_solutes_dict(solute_dict: dict, units: str):
     Args:
         solute_dict: The dictionary to format. This must be of the form dict{str: Number}
             e.g. {"Na+": 0.5, "Cl-": 0.9}
-        units: The units to use for the solute.
+        units: The units to use for the solute. e.g. "mol/kg"
 
     Returns:
         A formatted solute dictionary.
 
     Raises:
-        TypeError if `solute_dict` is invalid.
+        TypeError if `solute_dict` is not a dictionary.
     """
     if not isinstance(solute_dict, dict):
         raise TypeError("solute_dict must be a dictionary. Refer to the doc for proper formatting.")
 
-    for key, value in solute_dict.items():
-        solute_dict[key] = f"{value!s} {units}"
-
-    return solute_dict
+    return {key: f"{value!s} {units}" for key, value in solute_dict.items()}
 
 
 class FormulaDict(UserDict):

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -32,6 +32,28 @@ def standardize_formula(formula: str):
     return Ion.from_formula(formula).reduced_formula
 
 
+def format_solute(solute_dict: dict, units: str):
+    """
+    Format a solute dictionary with the given units.
+
+    Args:
+        solute_dict: The dictionary to format.
+
+    Returns:
+        A formatted solute dictionary.
+
+    Raises:
+        TypeError if `solute_dict` is invalid.
+    """
+    if not isinstance(solute_dict, dict):
+        raise TypeError("solute_dict must be a dictionary of the format ...")
+
+    for key, value in solute_dict.items():
+        solute_dict[key] = f"{str(value)} {units}"
+
+    return solute_dict
+
+
 class FormulaDict(UserDict):
     """
     Automatically converts keys on get/set using pymatgen.core.Ion.from_formula(key).reduced_formula.

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -38,6 +38,7 @@ def format_solute(solute_dict: dict, units: str):
 
     Args:
         solute_dict: The dictionary to format.
+        units: The units to use for the solute.
 
     Returns:
         A formatted solute dictionary.
@@ -49,7 +50,7 @@ def format_solute(solute_dict: dict, units: str):
         raise TypeError("solute_dict must be a dictionary of the format ...")
 
     for key, value in solute_dict.items():
-        solute_dict[key] = f"{str(value)} {units}"
+        solute_dict[key] = f"{value!s} {units}"
 
     return solute_dict
 

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -32,12 +32,14 @@ def standardize_formula(formula: str):
     return Ion.from_formula(formula).reduced_formula
 
 
-def format_solute(solute_dict: dict, units: str):
+def format_solutes_dict(solute_dict: dict, units: str):
     """
-    Format a solute dictionary with the given units.
+    Formats a dictionary of solutes by converting the amount to a string with the provided units suitable for passing to
+    use with the Solution class. Note that all solutes must be given in the same units.
 
     Args:
-        solute_dict: The dictionary to format.
+        solute_dict: The dictionary to format. This must be of the form dict{str: Number}
+            e.g. {"Na+": 0.5, "Cl-": 0.9}
         units: The units to use for the solute.
 
     Returns:
@@ -47,7 +49,7 @@ def format_solute(solute_dict: dict, units: str):
         TypeError if `solute_dict` is invalid.
     """
     if not isinstance(solute_dict, dict):
-        raise TypeError("solute_dict must be a dictionary of the format ...")
+        raise TypeError("solute_dict must be a dictionary. Refer to the doc for proper formatting.")
 
     for key, value in solute_dict.items():
         solute_dict[key] = f"{value!s} {units}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ Tests of pyEQL.utils module
 
 """
 
-from pyEQL.utils import FormulaDict, standardize_formula
+from pyEQL.utils import FormulaDict, format_solute, standardize_formula
 
 
 def test_standardize_formula():
@@ -35,3 +35,12 @@ def test_formula_dict():
     assert d.get("Na+") == 0.5
     d.update({"Br-": 2})
     assert d["Br[-]"] == 2
+
+
+def test_format_solute():
+    """
+    Test formatting solute dictionaries
+    """
+    test = {"Na+": 0.5, "Cl-": 0.5}
+    base = {"Na+": "0.5 mol/kg", "Cl-": "0.5 mol/kg"}
+    assert format_solute(test, units="mol/kg") == base

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,9 @@
 Tests of pyEQL.utils module
 
 """
+from pytest import raises
 
-from pyEQL.utils import FormulaDict, format_solute, standardize_formula
+from pyEQL.utils import FormulaDict, format_solutes_dict, standardize_formula
 
 
 def test_standardize_formula():
@@ -43,4 +44,9 @@ def test_format_solute():
     """
     test = {"Na+": 0.5, "Cl-": 0.5}
     base = {"Na+": "0.5 mol/kg", "Cl-": "0.5 mol/kg"}
-    assert format_solute(test, units="mol/kg") == base
+    assert format_solutes_dict(test, units="mol/kg") == base
+
+    bad_test = [["Na+", 0.5], ["Cl-", 0.5]]
+    error_msg = "solute_dict must be a dictionary. Refer to the doc for proper formatting."
+    with raises(TypeError, match=error_msg):
+        format_solutes_dict(bad_test, units="mol/kg")


### PR DESCRIPTION
## Summary

Major changes:

- Add in the utility method `format_solute` to format a solute dictionary with the provided unit. (Closes #53)

## Todos

If this is work in progress, what else needs to be done?

- Need help with the documentation

## Checklist

- [x] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [ ] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.
<!-- - [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) -->

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
