### PR TITLE
 Replace autogenerate() with a Solution class method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `format_solutes_dict()` method added into the utils module to help format solutes dictionaries with a unit.
+- `Solution`: new method `to_file()` for more convenient saving Solution object to json or yaml files.
+- `Solution`: new method `from_file()` for more convenient loading Solution object from json or yaml files.
+- `Solution`: new classmethod `from_preset()` to `replace pyEQL.functions.autogenerate()` and instantiate a solution from a preset composition.
 
 ## [0.9.0] - 2023-10-17
 

--- a/presets/Ringers lactate.yaml
+++ b/presets/Ringers lactate.yaml
@@ -1,0 +1,20 @@
+'@module': pyEQL.solution
+'@class': Solution
+'@version': 0.0.post1.dev699+g0764b1c
+solutes:
+  H2O(aq): 55.2313771443148 mol
+  Na[+1]: 0.13 mol
+  Cl[-1]: 0.109 mol
+  H5(CO)3[-1]: 0.028 mol
+  K[+1]: 0.004 mol
+  Ca[+2]: 0.0015 mol
+  H[+1]: 3.162277660168379e-07 mol
+  OH[-1]: 3.162277660168379e-08 mol
+volume: 1 l
+temperature: 298.15 K
+pressure: 1 atm
+pH: 6.5
+pE: 8.5
+balance_charge:
+solvent: H2O(aq)
+engine: native

--- a/presets/normal saline.yaml
+++ b/presets/normal saline.yaml
@@ -1,0 +1,17 @@
+'@module': pyEQL.solution
+'@class': Solution
+'@version': 0.0.post1.dev699+g0764b1c
+solutes:
+  H2O(aq): 55.19703719794332 mol
+  Na[+1]: 0.154 mol
+  Cl[-1]: 0.154 mol
+  H[+1]: 1e-07 mol
+  OH[-1]: 1e-07 mol
+volume: 1 l
+temperature: 298.15 K
+pressure: 1 atm
+pH: 7.0
+pE: 8.5
+balance_charge:
+solvent: H2O(aq)
+engine: native

--- a/presets/rainwater.yaml
+++ b/presets/rainwater.yaml
@@ -1,0 +1,17 @@
+'@module': pyEQL.solution
+'@class': Solution
+'@version': 0.0.post1.dev699+g0764b1c
+solutes:
+  H2O(aq): 55.34454944845822 mol
+  HCO3[-1]: 3.162277660168379e-06 mol
+  H[+1]: 1e-06 mol
+  OH[-1]: 1e-08 mol
+  CO3[-2]: 1e-09 mol
+volume: 1 l
+temperature: 298.15 K
+pressure: 1 atm
+pH: 6.0
+pE: 8.5
+balance_charge:
+solvent: H2O(aq)
+engine: native

--- a/presets/seawater.yaml
+++ b/presets/seawater.yaml
@@ -1,0 +1,39 @@
+'@module': pyEQL.solution
+'@class': Solution
+'@version': 0.0.post1.dev699+g0764b1c
+solutes:
+  H2O(aq): 55.34455401423017 mol
+  Cl[-1]: 0.54425785619973 mol
+  Na[+1]: 0.4675827371496296 mol
+  Mg[+2]: 0.05266118052346798 mol
+  SO4[-2]: 0.02815187344845402 mol
+  Ca[+2]: 0.010251594148212317 mol
+  K[+1]: 0.010177468379526855 mol
+  HCO3[-1]: 0.0017126511769261989 mol
+  Br[-1]: 0.0008395244921424561 mol
+  B(OH)3(aq): 0.0003134669156396757 mol
+  CO3[-2]: 0.00023825904349479544 mol
+  B(OH)4(aq): 0.0001005389715937341 mol
+  Sr[+2]: 9.046483353663284e-05 mol
+  F[-1]: 6.822478260456777e-05 mol
+  CO2(aq): 9.515218476861173e-06 mol
+  OH[-1]: 8.207436858780224e-06 mol
+  H[+1]: 7.943282347242822e-09 mol
+volume: 1.0080615264452506 l
+temperature: 298.15 K
+pressure: 1 atm
+pH: 8.103487039827968
+pE: 8.5
+balance_charge:
+solvent: H2O(aq)
+engine: native
+database:
+  '@module': maggma.stores.mongolike
+  '@class': JSONStore
+  '@version': 0.57.4
+  paths:
+  - /workspaces/pyEQL/src/pyEQL/database/pyeql_db.json
+  read_only: true
+  serialization_option:
+  serialization_default:
+  key: formula

--- a/presets/seawater.yaml
+++ b/presets/seawater.yaml
@@ -27,13 +27,3 @@ pE: 8.5
 balance_charge:
 solvent: H2O(aq)
 engine: native
-database:
-  '@module': maggma.stores.mongolike
-  '@class': JSONStore
-  '@version': 0.57.4
-  paths:
-  - /workspaces/pyEQL/src/pyEQL/database/pyeql_db.json
-  read_only: true
-  serialization_option:
-  serialization_default:
-  key: formula

--- a/presets/urine.yaml
+++ b/presets/urine.yaml
@@ -1,0 +1,26 @@
+'@module': pyEQL.solution
+'@class': Solution
+'@version': 0.0.post1.dev699+g0764b1c
+solutes:
+  H2O(aq): 55.135679438263864 mol
+  H4CN2O(aq): 0.333026615820163 mol
+  Na[+1]: 0.26098565526795925 mol
+  Cl[-1]: 0.05359207965475418 mol
+  K[+1]: 0.038364839391994025 mol
+  H4N[+1]: 0.027718552470665455 mol
+  SO4[-2]: 0.018737781405042127 mol
+  PO4[-3]: 0.012635387918307416 mol
+  H7C4N3O(aq): 0.008840335409397701 mol
+  HCO3[-1]: 0.004916675462052772 mol
+  Mg[+2]: 0.004114379757251594 mol
+  H4C5N4O3(aq): 0.0017845430730997621 mol
+  H[+1]: 1e-07 mol
+  OH[-1]: 1e-07 mol
+volume: 1 l
+temperature: 298.15 K
+pressure: 1 atm
+pH: 7.0
+pE: 8.5
+balance_charge:
+solvent: H2O(aq)
+engine: native

--- a/presets/wastewater.yaml
+++ b/presets/wastewater.yaml
@@ -1,0 +1,21 @@
+'@module': pyEQL.solution
+'@class': Solution
+'@version': 0.0.post1.dev699+g0764b1c
+solutes:
+  H2O(aq): 55.342123269143364 mol
+  CH3COOH(aq): 0.006827420786931851 mol
+  Cl[-1]: 0.0016641751050686824 mol
+  H3N(aq): 0.0014268501490265714 mol
+  K[+1]: 0.0004092249535146029 mol
+  SO4[-2]: 0.00027065684251727516 mol
+  PO4[-3]: 8.002412348261364e-05 mol
+  H[+1]: 1e-07 mol
+  OH[-1]: 1e-07 mol
+volume: 1 l
+temperature: 298.15 K
+pressure: 1 atm
+pH: 7.0
+pE: 8.5
+balance_charge:
+solvent: H2O(aq)
+engine: native

--- a/src/pyEQL/functions.py
+++ b/src/pyEQL/functions.py
@@ -305,7 +305,9 @@ def mix(s1, s2):
     return s1 + s2
 
 
-@deprecated
+@deprecated(
+    message="autogenerate() is deprecated and will be removed in the next release! Use Solution.from_preset() instead.)"
+)
 def autogenerate(
     solution: Literal["seawater", "rainwater", "wastewater", "urine", "Ringers lactate", "normal saline"]
 ):  # pragma: no cover

--- a/src/pyEQL/functions.py
+++ b/src/pyEQL/functions.py
@@ -305,7 +305,10 @@ def mix(s1, s2):
     return s1 + s2
 
 
-def autogenerate(solution: Literal["seawater", "rainwater", "wastewater", "urine", "Ringers lactate", "normal saline"]):
+@deprecated
+def autogenerate(
+    solution: Literal["seawater", "rainwater", "wastewater", "urine", "Ringers lactate", "normal saline"]
+):  # pragma: no cover
     """
     This method provides a quick way to create Solution objects representing
     commonly-encountered solutions, such as seawater, rainwater, and wastewater.

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -20,7 +20,7 @@ from iapws import IAPWS95
 from maggma.stores import JSONStore, Store
 from monty.dev import deprecated
 from monty.json import MontyDecoder, MSONable
-from monty.serialization import dumpfn
+from monty.serialization import dumpfn, loadfn
 from pint import DimensionalityError, Quantity
 from pymatgen.core import Element
 from pymatgen.core.ion import Ion
@@ -3281,3 +3281,32 @@ class Solution(MSONable):
             dumpfn(solution_dict, file_path)
         else:
             dumpfn(self, file_path)
+
+    def from_file(self, file_path: str) -> Solution | None:
+        """Loading from a .yaml or .json file.
+
+        Args:
+            file_path (str): _description_
+        """
+        if not os.path.exists(file_path):
+            logger.error("Invalid path to file entered - %s" % file_path)
+            return None
+        if "yaml" in file_path.lower():
+            true_keys = [
+                "solutes",
+                "volume",
+                "temperature",
+                "pressure",
+                "pH",
+                "pE",
+                "balance_charge",
+                "solvent",
+                "engine",
+                # "database",
+            ]
+            solution_dict = loadfn(file_path)
+            keys_to_delete = [key for key in solution_dict if key not in true_keys]
+            for key in keys_to_delete:
+                solution_dict.pop(key)
+            return Solution(**solution_dict)
+        return loadfn(solution_dict)

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -8,12 +8,14 @@ pyEQL Solution Class.
 from __future__ import annotations
 
 import math
+import os
 import warnings
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal
 
 import numpy as np
+import yaml
 from iapws import IAPWS95
 from maggma.stores import JSONStore, Store
 from monty.dev import deprecated
@@ -3228,3 +3230,34 @@ class Solution(MSONable):
         :py:meth:`get_salt_dict`
         """
         return self.get_salt_dict()
+
+    @classmethod
+    def from_preset(cls, preset: str) -> Solution:
+        """Instantiate a solution from a preset composition
+
+        Args:
+            preset (str): a named preset e.g. 'seawater' or the path to a .yaml file that defines the desired preset
+
+        Returns:
+            Solution
+        """
+        # Path to the YAML file corresponding to the preset
+        yaml_path = os.path.join("presets", f"{preset}.yaml")
+
+        # Check if the file exists
+        if not os.path.exists(yaml_path):
+            raise FileNotFoundError(f"File '{yaml_path}' not found!")
+
+        # Load the yaml file corresponding to the preset
+        with open(yaml_path) as file:
+            data = yaml.load(file, Loader=yaml.FullLoader)
+
+        # Extract data from the yaml file
+        temperature = data["temperature"]
+        pressure = data["pressure"]
+        pH = data["pH"]
+        solutes = data["solutes"]
+        # solutes = [[solute["name"], solute["concentration"]] for solute in solutes]
+
+        # Create and return a Solution object
+        return cls(solutes=solutes, temperature=temperature, pressure=pressure, pH=pH)

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -3232,7 +3232,7 @@ class Solution(MSONable):
         return self.get_salt_dict()
 
     @classmethod
-    def from_preset(cls, preset: str) -> Solution:
+    def from_preset(cls, preset: str) -> Solution | None:
         """Instantiate a solution from a preset composition
 
         Args:

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -3243,25 +3243,34 @@ class Solution(MSONable):
         Returns:
             A pyEQL Solution object.
         """
+        # Path to the YAML and JSON files corresponding to the preset
+        yaml_path = os.path.join("presets", f"{preset}.yaml")
+        json_path = os.path.join("presets", f"{preset}.json")
+
         # Check if the file exists
-        if not os.path.exists(preset):
+        if os.path.exists(yaml_path):
+            preset_path = yaml_path
+        elif os.path.exists(json_path):
+            preset_path = json_path
+        else:
             logger.error("Invalid solution entered - %s" % preset)
-            raise FileNotFoundError(f"File '{preset}' not found!")
+            raise FileNotFoundError(f"Files '{yaml_path}' and '{json_path} not found!")
 
         # Create and return a Solution object
-        return cls().from_file(preset)
+        return cls().from_file(preset_path)
 
     def to_file(self, filename: str | Path) -> None:
         """Saving to a .yaml or .json file.
 
         Args:
-            filename (Union[str, Path]): The path to the file to save Solution.
+            filename (str | Path): The path to the file to save Solution.
               Valid extensions are .json or .yaml.
         """
-        if not ("yaml" in filename.lower() or "json" in filename.lower()):
-            logger.error("Invalid path to file entered - %s" % filename)
-            raise FileNotFoundError(f"File '{filename}' not found!")
-        if "yaml" in filename.lower():
+        str_filename = str(filename)
+        if not ("yaml" in str_filename.lower() or "json" in str_filename.lower()):
+            logger.error("Invalid path to file entered - %s" % str_filename)
+            raise FileNotFoundError(f"File '{str_filename}' not found!")
+        if "yaml" in str_filename.lower():
             solution_dict = self.as_dict()
             dumpfn(solution_dict, filename)
         else:
@@ -3271,13 +3280,14 @@ class Solution(MSONable):
         """Loading from a .yaml or .json file.
 
         Args:
-            filename (Union[str, Path]): Path to the .json or .yaml file (including extension) to load the Solution from.
+            filename (str | Path): Path to the .json or .yaml file (including extension) to load the Solution from.
               Valid extensions are .json or .yaml.
         """
         if not os.path.exists(filename):
             logger.error("Invalid path to file entered - %s" % filename)
             raise FileNotFoundError(f"File '{filename}' not found!")
-        if "yaml" in filename.lower():
+        str_filename = str(filename)
+        if "yaml" in str_filename.lower():
             true_keys = [
                 "solutes",
                 "volume",
@@ -3295,4 +3305,4 @@ class Solution(MSONable):
             for key in keys_to_delete:
                 solution_dict.pop(key)
             return Solution(**solution_dict)
-        return loadfn(solution_dict)
+        return loadfn(filename)

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -20,6 +20,7 @@ from iapws import IAPWS95
 from maggma.stores import JSONStore, Store
 from monty.dev import deprecated
 from monty.json import MontyDecoder, MSONable
+from monty.serialization import dumpfn
 from pint import DimensionalityError, Quantity
 from pymatgen.core import Element
 from pymatgen.core.ion import Ion
@@ -3261,3 +3262,22 @@ class Solution(MSONable):
 
         # Create and return a Solution object
         return cls(solutes=solutes, temperature=temperature, pressure=pressure, pH=pH)
+
+    def to_file(self, file_name: str, extension: str = "yaml") -> None:
+        """Saving to a .yaml or .json file.
+
+        Args:
+            file_name (str): The name of the file with the saved Solution
+            extension (str, optional): The extension of the save file.
+              Valid entries are 'yaml' and 'json'.
+              Defaults to 'yaml'.
+        """
+        if extension not in ["json", "yaml"]:
+            logger.error("Invalid extension entered - %s" % extension)
+            return
+        file_path = os.path.join("presets", f"{file_name}.{extension}")
+        if extension == "yaml":
+            solution_dict = self.as_dict()
+            dumpfn(solution_dict, file_path)
+        else:
+            dumpfn(self, file_path)

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -3228,7 +3228,9 @@ class Solution(MSONable):
         return self.get_salt_dict()
 
     @classmethod
-    def from_preset(cls, preset: str) -> Solution:
+    def from_preset(
+        cls, preset: Literal["seawater", "rainwater", "wastewater", "urine", "normal saline", "Ringers lactate"]
+    ) -> Solution:
         """Instantiate a solution from a preset composition
 
         Args:
@@ -3241,6 +3243,29 @@ class Solution(MSONable):
 
         Raises:
             FileNotFoundError: If the given preset file doesn't exist on the file system.
+
+        Notes
+        -----
+        The following sections explain the different solution options:
+
+        - 'rainwater' - pure water in equilibrium with atmospheric CO2 at pH 6
+        - 'seawater' or 'SW'- Standard Seawater. See Table 4 of the Reference for Composition [1]_
+        - 'wastewater' or 'WW' - medium strength domestic wastewater. See Table 3-18 of [2]_
+        - 'urine' - typical human urine. See Table 3-15 of [2]_
+        - 'normal saline' or 'NS' - normal saline solution used in medicine [3]_
+        - 'Ringers lacatate' or 'RL' - Ringer's lactate solution used in medicine [4]_
+
+        References:
+        ----------
+            .. [1] Millero, Frank J. "The composition of Standard Seawater and the definition of
+                the Reference-Composition Salinity Scale." *Deep-sea Research. Part I* 55(1), 2008, 50-72.
+
+            .. [2] Metcalf & Eddy, Inc. et al. *Wastewater Engineering: Treatment and Resource Recovery*, 5th Ed.
+                    McGraw-Hill, 2013.
+
+            .. [3] https://en.wikipedia.org/wiki/Saline_(medicine)
+
+            .. [4] https://en.wikipedia.org/wiki/Ringer%27s_lactate_solution
         """
         # Path to the YAML and JSON files corresponding to the preset
         yaml_path = os.path.join("presets", f"{preset}.yaml")
@@ -3267,8 +3292,8 @@ class Solution(MSONable):
         """
         str_filename = str(filename)
         if not ("yaml" in str_filename.lower() or "json" in str_filename.lower()):
-            logger.error("Invalid path to file entered - %s" % str_filename)
-            raise FileNotFoundError(f"File '{str_filename}' not found!")
+            logger.error("Invalid file extension entered - %s" % str_filename)
+            raise ValueError("File extension must be .json or .yaml")
         if "yaml" in str_filename.lower():
             solution_dict = self.as_dict()
             solution_dict.pop("database")

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -3254,40 +3254,38 @@ class Solution(MSONable):
             preset_path = json_path
         else:
             logger.error("Invalid solution entered - %s" % preset)
-            raise FileNotFoundError(f"Files '{yaml_path}' and '{json_path} not found!")
+            raise FileNotFoundError(f"Files '{yaml_path}' and '{json_path}' not found!")
 
         # Create and return a Solution object
         return cls().from_file(preset_path)
 
-    def to_file(self, file_name: str, extension: str = "yaml") -> None:
+    def to_file(self, filename: str | Path) -> None:
         """Saving to a .yaml or .json file.
 
         Args:
-            file_name (str): The name of the file with the saved Solution
-            extension (str, optional): The extension of the save file.
-              Valid entries are 'yaml' and 'json'.
-              Defaults to 'yaml'.
+            filename (Union[str, Path]): The path to the file to save Solution.
+              Valid extensions are .json or .yaml.
         """
-        if extension not in ["json", "yaml"]:
-            logger.error("Invalid extension entered - %s" % extension)
-            return
-        file_path = os.path.join("presets", f"{file_name}.{extension}")
-        if extension == "yaml":
+        if not ("yaml" in filename.lower() or "json" in filename.lower()):
+            logger.error("Invalid path to file entered - %s" % filename)
+            raise FileNotFoundError(f"File '{filename}' not found!")
+        if "yaml" in filename.lower():
             solution_dict = self.as_dict()
-            dumpfn(solution_dict, file_path)
+            dumpfn(solution_dict, filename)
         else:
-            dumpfn(self, file_path)
+            dumpfn(self, filename)
 
-    def from_file(self, file_path: str) -> Solution | None:
+    def from_file(self, filename: str | Path) -> Solution | None:
         """Loading from a .yaml or .json file.
 
         Args:
-            file_path (str): _description_
+            filename (Union[str, Path]): Path to the .json or .yaml file (including extension) to load the Solution from.
+              Valid extensions are .json or .yaml.
         """
-        if not os.path.exists(file_path):
-            logger.error("Invalid path to file entered - %s" % file_path)
-            return None
-        if "yaml" in file_path.lower():
+        if not os.path.exists(filename):
+            logger.error("Invalid path to file entered - %s" % filename)
+            raise FileNotFoundError(f"File '{filename}' not found!")
+        if "yaml" in filename.lower():
             true_keys = [
                 "solutes",
                 "volume",
@@ -3300,7 +3298,7 @@ class Solution(MSONable):
                 "engine",
                 # "database",
             ]
-            solution_dict = loadfn(file_path)
+            solution_dict = loadfn(filename)
             keys_to_delete = [key for key in solution_dict if key not in true_keys]
             for key in keys_to_delete:
                 solution_dict.pop(key)

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -3232,7 +3232,7 @@ class Solution(MSONable):
         return self.get_salt_dict()
 
     @classmethod
-    def from_preset(cls, preset: str) -> Solution | None:
+    def from_preset(cls, preset: str) -> Solution:
         """Instantiate a solution from a preset composition
 
         Args:
@@ -3242,6 +3242,9 @@ class Solution(MSONable):
 
         Returns:
             A pyEQL Solution object.
+
+        Raises:
+            FileNotFoundError: If the given preset file doesn't exist on the file system.
         """
         # Path to the YAML and JSON files corresponding to the preset
         yaml_path = os.path.join("presets", f"{preset}.yaml")
@@ -3272,16 +3275,23 @@ class Solution(MSONable):
             raise FileNotFoundError(f"File '{str_filename}' not found!")
         if "yaml" in str_filename.lower():
             solution_dict = self.as_dict()
+            solution_dict.pop("database")
             dumpfn(solution_dict, filename)
         else:
             dumpfn(self, filename)
 
-    def from_file(self, filename: str | Path) -> Solution | None:
+    def from_file(self, filename: str | Path) -> Solution:
         """Loading from a .yaml or .json file.
 
         Args:
             filename (str | Path): Path to the .json or .yaml file (including extension) to load the Solution from.
               Valid extensions are .json or .yaml.
+
+        Returns:
+            A pyEQL Solution object.
+
+        Raises:
+            FileNotFoundError: If the given filename doesn't exist on the file system.
         """
         if not os.path.exists(filename):
             logger.error("Invalid path to file entered - %s" % filename)

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -3243,21 +3243,13 @@ class Solution(MSONable):
         Returns:
             A pyEQL Solution object.
         """
-        # Path to the YAML and JSON files corresponding to the preset
-        yaml_path = os.path.join("presets", f"{preset}.yaml")
-        json_path = os.path.join("presets", f"{preset}.json")
-
         # Check if the file exists
-        if os.path.exists(yaml_path):
-            preset_path = yaml_path
-        elif os.path.exists(json_path):
-            preset_path = json_path
-        else:
+        if not os.path.exists(preset):
             logger.error("Invalid solution entered - %s" % preset)
-            raise FileNotFoundError(f"Files '{yaml_path}' and '{json_path}' not found!")
+            raise FileNotFoundError(f"File '{preset}' not found!")
 
         # Create and return a Solution object
-        return cls().from_file(preset_path)
+        return cls().from_file(preset)
 
     def to_file(self, filename: str | Path) -> None:
         """Saving to a .yaml or .json file.

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -609,5 +609,5 @@ def test_test_to_from_file(tmpdir, s1):
         assert pytest.approx(loaded_s1.volume.to("L").magnitude) == s1.volume.to("L").magnitude
     # test invalid extension raises error
     filename = tmp_path / "test_solution.txt"
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(ValueError, match=r"File extension must be .json or .yaml"):
         s1.to_file(filename)


### PR DESCRIPTION
## Summary
Issue #63

Major changes: 
- Added `from_preset` Class Method to Solution - this new method allows for the instantiation of a `Solution` object directly from predefined presets stored in yaml or json files.
- Added methods `from_file` and `to_file` for more convenient save and load Solution object to or from json or yaml files.

## Todos

If this is work in progress, what else needs to be done?

- [x] Add tests for `from_preset` class method
- [x] Add tests for `from_file` and `to_file` methods
- [x] Add the ability to read parameters from json files
- [ ] Add reading not only the full names of presets, but also abbreviations
- [x] Add preset yaml/json files (?)
- [x] Update CHANGELOG.md

## Checklist

- [x] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.
<!-- - [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) -->

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
