### PR TITLE
Performance Improvements

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,6 +5,7 @@ developed and maintained by the Kingsbury Lab at Princeton University.
 
 Other contributors, listed alphabetically, are:
 
-* Hernan Grecco <hernan.grecco@gmail.com>
+* @DhruvDuseja
+* Hernan Grecco (@hgrecco)
 
 (If you think that your name belongs here, please let the maintainer know)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.1] - 2023-11-04
 
 ### Added
 
-- `format_solutes_dict()` method added into the utils module to help format solutes dictionaries with a unit.
+- `format_solutes_dict()` method added into the utils module to help format solutes dictionaries with a unit. (@DhruvDuseja)
+
+### Changed
+
+- Native property database is now instantiated on `pyEQL.__init__` to speed subsequent access by `Solution`
+- Numerous performance optimization increased the speed of many `Solution` property and method calls by 3x-10x
 
 ## [0.9.0] - 2023-10-17
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     pymatgen>=2023.10.11
     iapws
     monty
-    maggma
+    maggma>=0.57.5
     phreeqpython
 
 [options.packages.find]

--- a/src/pyEQL/__init__.py
+++ b/src/pyEQL/__init__.py
@@ -11,6 +11,8 @@ and performing chemical thermodynamics computations.
 from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 
 from pint import UnitRegistry
+from pathlib import Path
+from maggma.stores import JSONStore
 from pkg_resources import resource_filename
 
 try:
@@ -39,6 +41,14 @@ ureg.enable_contexts("chem")
 # set the default string formatting for pint quantities
 ureg.default_format = "P~"
 
+# create a Store for the default database
+database_dir = resource_filename("pyEQL", "database")
+json = Path(database_dir) / "pyeql_db.json"
+IonDB = JSONStore(str(json), key="formula")
+# By calling connect on init, we get the expensive JSON reading operation out
+# of the way. Subsequent calls to connect will bypass this and access the already-
+# instantiated Store in memory, which should speed up instantiation of Solution objects.
+IonDB.connect()
 
 from pyEQL.functions import *  # noqa: E402, F403
 from pyEQL.solution import Solution  # noqa: E402

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -593,6 +593,9 @@ class PhreeqcEOS(EOS):
         )
         self.database = phreeqc_db
 
+        # create the PhreeqcPython instance
+        self.pp = PhreeqPython(database=self.database, database_directory=self.db_path)
+
     def _setup_ppsol(self, solution):
         """
         Helper method to set up a PhreeqPython solution for subsequent analysis
@@ -637,12 +640,9 @@ class PhreeqcEOS(EOS):
                 key += " charge"
             d[key] = mol / solv_mass
 
-        # create the PhreeqcPython instance
-        pp = PhreeqPython(database=self.database, database_directory=self.db_path)
-
         # create the PHREEQC solution object
         try:
-            ppsol = pp.add_solution(d)
+            ppsol = self.pp.add_solution(d)
         except Exception as e:
             print(d)
             # catch problems with the input to phreeqc

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -680,12 +680,7 @@ class PhreeqcEOS(EOS):
         k = el + chg
 
         # calculate the molal scale activity coefficient
-        try:
-            act = ppsol.activity(k, "mol") / ppsol.molality(k, "mol")
-        except ZeroDivisionError:
-            # assume this means the solute does not exist
-            logger.warning(f"Solute {solute} not found in solution. returning 0 activity")
-            act = 0
+        act = ppsol.activity(k, "mol") / ppsol.molality(k, "mol")
 
         # remove the PPSol from the phreeqcpython instance
         self._destroy_ppsol(ppsol)

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -429,7 +429,7 @@ class NativeEOS(EOS):
             # solution.get_amount(Salt.anion,'mol/kg')/Salt.nu_anion)/2
 
             # get the effective molality of the salt
-            concentration = d["mol"] * ureg.Quantity("mol") / solution.solvent_mass
+            concentration = ureg.Quantity(d["mol"], "mol") / solution.solvent_mass
 
             molality_sum += concentration
 
@@ -463,7 +463,7 @@ class NativeEOS(EOS):
                     "Cannot calculate osmotic coefficient because Pitzer parameters for salt %s are not specified. Returning unit osmotic coefficient"
                     % item.formula
                 )
-                effective_osmotic_sum += concentration * ureg.Quantity("1 dimensionless")
+                effective_osmotic_sum += concentration * osmotic_coefficient
 
         try:
             return effective_osmotic_sum / molality_sum
@@ -545,7 +545,7 @@ class NativeEOS(EOS):
 
             part_vol = solution.get_property(solute, "size.molar_volume")
             if part_vol is not None:
-                solute_vol += part_vol * mol * ureg.Quantity("1 mol")
+                solute_vol += part_vol * ureg.Quantity(mol, "mol")
                 logger.info("Updated solution volume using direct partial molar volume for solute %s" % solute)
 
             else:
@@ -685,7 +685,7 @@ class PhreeqcEOS(EOS):
         # remove the PPSol from the phreeqcpython instance
         self._destroy_ppsol(ppsol)
 
-        return act * ureg.Quantity("1 dimensionless")
+        return ureg.Quantity(act, "dimensionless")
 
     def get_osmotic_coefficient(self, solution):
         """

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -672,15 +672,20 @@ class PhreeqcEOS(EOS):
 
         # translate the species into keys that phreeqc will understand
         k = standardize_formula(solute)
-        el = k.split("[")[0]
-        chg = k.split("[")[1].split("]")[0]
+        spl = k.split("[")
+        el = spl[0]
+        chg = spl[1].split("]")[0]
         if chg[-1] == "1":
             chg = chg[0]  # just pass + or -, not +1 / -1
         k = el + chg
 
         # calculate the molal scale activity coefficient
-        print(k)
-        act = ppsol.activity(k, "mol") / ppsol.molality(k, "mol")
+        try:
+            act = ppsol.activity(k, "mol") / ppsol.molality(k, "mol")
+        except ZeroDivisionError:
+            # assume this means the solute does not exist
+            logger.warning(f"Solute {solute} not found in solution. returning 0 activity")
+            act = 0
 
         # remove the PPSol from the phreeqcpython instance
         self._destroy_ppsol(ppsol)

--- a/src/pyEQL/equilibrium.py
+++ b/src/pyEQL/equilibrium.py
@@ -162,7 +162,7 @@ def adjust_temp_pitzer(c1, c2, c3, c4, c5, temp, temp_ref=ureg.Quantity("298.15 
     )
 
 
-def adjust_temp_vanthoff(equilibrium_constant, enthalpy, temperature, reference_temperature=25 * ureg.Quantity("degC")):
+def adjust_temp_vanthoff(equilibrium_constant, enthalpy, temperature, reference_temperature=ureg.Quantity(25, "degC")):
     r"""(float,float,number, optional number) -> float.
 
     Adjust a reaction equilibrium constant from one temperature to another.
@@ -227,7 +227,7 @@ def adjust_temp_arrhenius(
     rate_constant,
     activation_energy,
     temperature,
-    reference_temperature=25 * ureg.Quantity("degC"),
+    reference_temperature=ureg.Quantity(25, "degC"),
 ):
     r"""(float,float,number, optional number) -> float.
 
@@ -363,7 +363,7 @@ def alpha(n, pH, pKa_list):
     k_term = 1
 
     # the 'item' index counts from 0 to the number of protons, inclusive
-    for item in range(0, num_protons + 1):
+    for item in range(num_protons + 1):
         # multiply the preceding k values together
         for i in range(len(pKa_list[:item])):
             k_term *= 10 ** -pKa_list[i]

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -22,7 +22,7 @@ from pint import DimensionalityError, Quantity
 from pymatgen.core import Element
 from pymatgen.core.ion import Ion
 
-from pyEQL import ureg
+from pyEQL import ureg, IonDB
 from pyEQL.engines import EOS, IdealEOS, NativeEOS, PhreeqcEOS
 
 # logging system
@@ -145,11 +145,8 @@ class Solution(MSONable):
 
         # connect to the desired property database
         if database is None:
-            from pkg_resources import resource_filename
-
-            database_dir = resource_filename("pyEQL", "database")
-            json = Path(database_dir) / "pyeql_db.json"
-            db_store = JSONStore(str(json), key="formula")
+            # load the default database, which is a JSONStore
+            db_store = IonDB
         elif isinstance(database, (str, Path)):
             db_store = JSONStore(str(database), key="formula")
             logger.info(f"Created maggma JSONStore from .json file {database}")

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -7,10 +7,12 @@ pyEQL utilities
 """
 
 from collections import UserDict
+from functools import lru_cache
 
 from pymatgen.core.ion import Ion
 
 
+@lru_cache
 def standardize_formula(formula: str):
     """
     Convert a chemical formula into standard form.

--- a/tests/test_phreeqc.py
+++ b/tests/test_phreeqc.py
@@ -110,6 +110,9 @@ def test_init_engines():
     assert isinstance(s.engine, PhreeqcEOS)
     assert s.get_activity_coefficient("Na+").magnitude * s.get_activity_coefficient("Cl-").magnitude < 1
     assert s.get_osmotic_coefficient().magnitude == 1
+    # with pytest.warns(match="Solute Mg+2 not found"):
+    assert s.get_activity_coefficient("Mg+2").magnitude == 1
+    assert s.get_activity("Mg+2").magnitude == 0
 
 
 def test_conductivity(s1, s2):


### PR DESCRIPTION
## Summary

Miscellaneous changes to improve pyEQL's speed. Reduces the time required for many common operations by 3x - 10x.

Major changes:

- reduce calls to `ureg.Quantity` by using magnitudes where feasible
- use `Quantity(float, 'unit') instead of `Quantity('float unit') which is substantially faster
- Instantiate and connect to the native database in `pyEQL.__init__` to speed up subsequent access by `Solution` objects
- expand use of `lru_cache` for solution properties
- various minor optimizations

Results (results of `%%timeit` (ms), before / after)

1. Instantiate a 2 mol/L NaCl `Solution`: 301 / 84
2. `s.get_activity_coefficient('Na+')`: 27 / 14
3. `s.conductivity`: 143 / 44
4. `s.ionic_strength`: 5 / 0.5
5. `s.get_transport_number('Na+'): 2.4 / 0.5