### PR TITLE
Fix link in README to pyscaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ Detailed documentation is available at [https://pyeql.readthedocs.io/](https://p
 pyEQL is licensed under LGPL.
 
 This project has been set up using PyScaffold 4.5. For details and usage
-information on PyScaffold see [](https://pyscaffold.org/).
+information on PyScaffold see [https://pyscaffold.org/]().

--- a/docs/database.md
+++ b/docs/database.md
@@ -3,7 +3,7 @@
 # Property Database
 
 pyEQL is distributed with a database of solute properties and model parameters needed to perform
-it's calculations. The database includes:
+its calculations. The database includes:
 
 - Molecular weight, charge, and other chemical informatics information for any species
 - Diffusion coefficients for 104 ions


### PR DESCRIPTION
This is the world's tiniest PR to fix an incorrectly formatted markdown link in the README :)

Old way: [](https://pyscaffold.org/).
New way: [https://pyscaffold.org/]()

Plus a small grammar fix.