### PR TITLE
Restore duplicate log filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2023-11-07
+
+### Fixed
+
+- Restored filter that suppresses duplicate log messages
+
 ## [0.9.1] - 2023-11-04
 
 ### Added

--- a/examples/pyeql_demo.ipynb
+++ b/examples/pyeql_demo.ipynb
@@ -8,7 +8,9 @@
    },
    "cell_type": "markdown",
    "id": "305d1216-9791-43dd-8d7f-ec90aa72a307",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# `pyEQL` Demonstration\n",
     "\n",
@@ -52,17 +54,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ryan/mambaforge/envs/pbx/code/pyEQL/src/pyEQL/__init__.py:52: FutureWarning: unitdeprecator is deprecated\n",
-      "The pyEQL UnitRegistry has been renamed from unit to ureg. Change 'from pyEQL import unit' to 'from pyEQL import ureg'!\n",
-      "  globals()[\"unit\"] = unitdeprecator()\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pyEQL import Solution"
    ]
@@ -72,17 +64,17 @@
    "execution_count": 2,
    "id": "c7193cc4-0830-461b-979e-49be9fabfe3f",
    "metadata": {
-    "scrolled": true
+    "tags": []
    },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING 2023-10-17 09:36:21,530 solution.py _get_property 2089 Partial molar volume for species H[+1] not corrected for temperature\n",
-      "WARNING 2023-10-17 09:36:21,538 solution.py _get_property 2089 Partial molar volume for species OH[-1] not corrected for temperature\n",
-      "WARNING 2023-10-17 09:36:21,788 solution.py _get_property 2089 Partial molar volume for species Mg[+2] not corrected for temperature\n",
-      "WARNING 2023-10-17 09:36:21,818 activity_correction.py _debye_parameter_volume 231 Debye-Huckel limiting slope for volume is approximate when T is not equal to 25 degC\n"
+      "WARNING 2023-11-07 11:18:03,638 solution.py _get_property 2084 Partial molar volume for species H[+1] not corrected for temperature\n",
+      "WARNING 2023-11-07 11:18:03,648 solution.py _get_property 2084 Partial molar volume for species OH[-1] not corrected for temperature\n",
+      "WARNING 2023-11-07 11:18:03,922 solution.py _get_property 2084 Partial molar volume for species Mg[+2] not corrected for temperature\n",
+      "WARNING 2023-11-07 11:18:03,951 activity_correction.py _debye_parameter_volume 231 Debye-Huckel limiting slope for volume is approximate when T is not equal to 25 degC\n"
      ]
     }
    ],
@@ -135,24 +127,20 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING 2023-10-17 09:36:21,869 solution.py viscosity_kinematic 599 Viscosity coefficients for MgCl2 not found. Viscosity will be approximate.\n",
-      "WARNING 2023-10-17 09:36:21,906 solution.py viscosity_kinematic 599 Viscosity coefficients for MgCl2 not found. Viscosity will be approximate.\n",
-      "WARNING 2023-10-17 09:36:21,944 solution.py viscosity_kinematic 599 Viscosity coefficients for MgCl2 not found. Viscosity will be approximate.\n",
-      "WARNING 2023-10-17 09:36:21,970 engines.py get_activity_coefficient 314 Ionic strength too high to estimate activity for species H[+1]. Specify parameters for Pitzer model. Returning unit activity coefficient\n",
-      "WARNING 2023-10-17 09:36:21,985 solution.py viscosity_kinematic 599 Viscosity coefficients for MgCl2 not found. Viscosity will be approximate.\n",
-      "WARNING 2023-10-17 09:36:22,008 engines.py get_activity_coefficient 314 Ionic strength too high to estimate activity for species OH[-1]. Specify parameters for Pitzer model. Returning unit activity coefficient\n"
+      "WARNING 2023-11-07 11:18:04,061 engines.py get_activity_coefficient 314 Ionic strength too high to estimate activity for species H[+1]. Specify parameters for Pitzer model. Returning unit activity coefficient\n",
+      "WARNING 2023-11-07 11:18:04,079 engines.py get_activity_coefficient 314 Ionic strength too high to estimate activity for species OH[-1]. Specify parameters for Pitzer model. Returning unit activity coefficient\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "3.299995263108894 S/m"
+       "3.299995263108893 S/m"
       ],
       "text/latex": [
-       "$3.299995263108894\\ \\frac{\\mathrm{S}}{\\mathrm{m}}$"
+       "$3.299995263108893\\ \\frac{\\mathrm{S}}{\\mathrm{m}}$"
       ],
       "text/plain": [
-       "3.299995263108894 <Unit('siemens / meter')>"
+       "3.299995263108893 <Unit('siemens / meter')>"
       ]
      },
      "execution_count": 4,
@@ -545,13 +533,13 @@
     {
      "data": {
       "text/html": [
-       "0.4099879515632778"
+       "0.40998795156327783"
       ],
       "text/latex": [
-       "$0.4099879515632778\\$"
+       "$0.40998795156327783\\$"
       ],
       "text/plain": [
-       "0.4099879515632778 <Unit('dimensionless')>"
+       "0.40998795156327783 <Unit('dimensionless')>"
       ]
      },
      "execution_count": 19,
@@ -659,7 +647,7 @@
       "text/plain": [
        "{'@module': 'pyEQL.solution',\n",
        " '@class': 'Solution',\n",
-       " '@version': '0.6.0.post1.dev23+g090ac81',\n",
+       " '@version': '0.9.0.post1.dev3+g22e5c4a',\n",
        " 'solutes': {'H2O(aq)': '55.238455538403954 mol',\n",
        "  'Cl[-1]': '0.38323989957700755 mol',\n",
        "  'Mg[+2]': '0.18323990520853942 mol',\n",
@@ -686,7 +674,7 @@
        " 'engine': 'native',\n",
        " 'database': {'@module': 'maggma.stores.mongolike',\n",
        "  '@class': 'JSONStore',\n",
-       "  '@version': '0.19.1.post1.dev1792+g0517496',\n",
+       "  '@version': '0.57.4',\n",
        "  'paths': ['/home/ryan/mambaforge/envs/pbx/code/pyEQL/src/pyEQL/database/pyeql_db.json'],\n",
        "  'read_only': True,\n",
        "  'serialization_option': None,\n",
@@ -775,8 +763,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING 2023-10-17 09:36:22,373 engines.py get_osmotic_coefficient 462 Cannot calculate osmotic coefficient because Pitzer parameters for salt HClO3 are not specified. Returning unit osmotic coefficient\n",
-      "WARNING 2023-10-17 09:36:22,384 engines.py get_osmotic_coefficient 462 Cannot calculate osmotic coefficient because Pitzer parameters for salt HClO2 are not specified. Returning unit osmotic coefficient\n"
+      "WARNING 2023-11-07 11:18:04,616 engines.py get_osmotic_coefficient 462 Cannot calculate osmotic coefficient because Pitzer parameters for salt HClO3 are not specified. Returning unit osmotic coefficient\n",
+      "WARNING 2023-11-07 11:18:04,621 engines.py get_osmotic_coefficient 462 Cannot calculate osmotic coefficient because Pitzer parameters for salt HClO2 are not specified. Returning unit osmotic coefficient\n"
      ]
     },
     {

--- a/src/pyEQL/logging_system.py
+++ b/src/pyEQL/logging_system.py
@@ -72,3 +72,7 @@ class Unique(logging.Filter):
             return False
         self.__logged[msg] = 1
         return True
+
+
+# add the filter to suppress duplicate messages
+logger.addFilter(Unique())


### PR DESCRIPTION
## Summary

`pyEQL` used to have a filter to suppress duplicate log messages (i.e., to ensure each log message was unique). This was inadvertently deactivated during the package overhaul before 0.6.0, leading to a distracting amount of log messages (see #52 and #64 )
