### PR TITLE
D temp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - 2023-11-10
+## [0.10.0] - 2023-11-12
 
 ### Added
 
-- `Solution`: new method `get_diffusion_coefficient` for dedicated retrieval of diffusion coefficients
+- `Solution`: Revamped docstrings for `conductivity`, `get_transport_number`, `get_molar_conductivity`, and
+  `get_diffusion_coefficient`.
+- `Solution`: new method `get_diffusion_coefficient` for dedicated retrieval of diffusion coefficients. This method
+  implements an improved algorithm for temperature adjustment and a new algorithm for adjusting infinite dilution D values
+  for ionic strengthe effects. The algorithm is identical to that implemented in PHREEQC >= 3.4.
 - Database: empirical parameters for temperature and ionic strength adjustment of diffusion coefficients for 15 solutes
+- Added tests for temperature and ionic strength adjustment and conductivity
 - Docs: new tutorial notebooks
 - Docs: remove duplicate contributing pages (Closes [#68](https://github.com/KingsburyLab/pyEQL/issues/68))
 - `Solution`: new method `to_file()` for more convenient saving Solution object to json or yaml files. (@kirill-push)
@@ -20,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Solution`: method af adjusting diffusion coefficients for temperature was updated (same as used in PHREEQC >= 3.4)
-- `Solution.conductvity`: improved equation (same as used in PHREEQC >= 3.4) which is more accurate at higher concentration
+- `Solution.conductvity`: improved equation (same as used in PHREEQC >= 3.4) which is more accurate at higher concentrations
 
 ### Fixed
 
@@ -30,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `replace pyEQL.functions.autogenerate()` is now deprecated. Use `from_preset` instead.
+
+### Removed
+
+- The `activity_correction` kwarg in `get_transport_number` has been removed, because this now occurs by default and is
+  handled in `get_diffusion_coefficient`.
 
 ## [0.9.2] - 2023-11-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Solution`: new method `get_diffusion_coefficient` for dedicated retrieval of diffusion coefficients
+- Database: empirical parameters for temperature and ionic strength adjustment of diffusion coefficients for 15 solutes
 - Docs: new tutorial notebooks
 - Docs: remove duplicate contributing pages (Closes [#68](https://github.com/KingsburyLab/pyEQL/issues/68))
 - `Solution`: new method `to_file()` for more convenient saving Solution object to json or yaml files. (@kirill-push)
 - `Solution`: new method `from_file()` for more convenient loading Solution object from json or yaml files. (@kirill-push)
 - `Solution`: new classmethod `from_preset()` to `replace pyEQL.functions.autogenerate()` and instantiate a solution from a preset composition. (@kirill-push)
 
+### Changed
+
+- `Solution`: method af adjusting diffusion coefficients for temperature was updated (same as used in PHREEQC >= 3.4)
+- `Solution.conductvity`: improved equation (same as used in PHREEQC >= 3.4) which is more accurate at higher concentration
+
 ### Fixed
 
+- Database errors with `Cs[+1]` diffusion coefficient and `KBr` Pitzer parameters
 - Restored filter that suppresses duplicate log messages
 
 ### Deprecated

--- a/src/pyEQL/database/pyeql_db.json
+++ b/src/pyEQL/database/pyeql_db.json
@@ -71,6 +71,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -147,6 +152,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -263,6 +273,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -350,6 +365,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -420,6 +440,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -490,6 +515,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -606,6 +636,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -694,6 +729,11 @@
                     "data_type": "fitted"
                 }
             },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            },
             "dielectric_zuber": {
                 "value": "2.87 dimensionless",
                 "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
@@ -776,6 +816,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -856,91 +901,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
-            }
-        }
-    },
-    {
-        "formula": "Au(CN)2[-1]",
-        "charge": -1,
-        "molecular_weight": "249.00136899999998 g/mol",
-        "elements": [
-            "Au",
-            "C",
-            "N"
-        ],
-        "chemsys": "Au-C-N",
-        "pmg_ion": {
-            "Au": 1,
-            "C": 2,
-            "N": 2,
-            "charge": -1,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "Au(CN)<sub>2</sub><sup>-1</sup>",
-        "formula_latex": "Au(CN)$_{2}$$^{-1}$",
-        "formula_hill": "C2 Au N2",
-        "formula_pretty": "Au(CN)2^-1",
-        "oxi_state_guesses": {
-            "Au": -1,
-            "C": 3,
-            "N": -3
-        },
-        "n_atoms": 5,
-        "n_elements": 3,
-        "size": {
-            "radius_ionic": {
-                "value": "None",
-                "reference": "pymatgen",
-                "data_type": "experimental"
             },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "2.14 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null
-        },
-        "thermo": {
-            "ΔG_hydration": null,
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": {
-                "value": "1.331e-05 cm**2/s",
-                "reference": "CRC",
-                "data_type": "experimental"
-            }
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "Max_C": null
-            },
-            "molar_volume_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "V_o": null,
-                "Max_C": null
-            },
-            "viscosity_jones_dole": {
-                "B": {
-                    "value": "-0.04 dm**3/mol",
-                    "reference": "https://doi.org/10.1021/cr00040a004",
-                    "data_type": "fitted"
-                }
-            },
-            "dielectric_zuber": {
-                "value": "8.48 dimensionless",
-                "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
-                "data_type": "fitted"
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -1017,6 +982,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -1088,6 +1058,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -1158,6 +1133,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -1228,6 +1208,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -1304,6 +1289,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -1380,6 +1370,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -1456,6 +1451,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -1534,6 +1534,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -1612,6 +1617,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -1704,6 +1714,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -1820,6 +1835,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -1909,101 +1929,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
-            }
-        }
-    },
-    {
-        "formula": "BaC4O.3H2O(aq)",
-        "charge": 0,
-        "molecular_weight": "255.41504 g/mol",
-        "elements": [
-            "Ba",
-            "C",
-            "H",
-            "O"
-        ],
-        "chemsys": "Ba-C-H-O",
-        "pmg_ion": {
-            "Ba": 1,
-            "C": 4,
-            "H": 6,
-            "O": 4,
-            "charge": 0,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "BaC<sub>4</sub>O<sub>.3</sub>H<sub>2</sub>O",
-        "formula_latex": "BaC$_{4}$O$_{.3}$H$_{2}$O",
-        "formula_hill": "C4 H6 Ba O4",
-        "formula_pretty": "BaC4O.3H2O",
-        "oxi_state_guesses": {
-            "Ba": 2,
-            "C": 0,
-            "H": 1,
-            "O": -2
-        },
-        "n_atoms": 15,
-        "n_elements": 4,
-        "size": {
-            "radius_ionic": {
-                "value": "None",
-                "reference": "pymatgen",
-                "data_type": "experimental"
             },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "2.68 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null
-        },
-        "thermo": {
-            "ΔG_hydration": null,
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": null
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": {
-                    "value": "0.2437 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta1": {
-                    "value": "1.093 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta2": {
-                    "value": "0.0 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Cphi": {
-                    "value": "-0.03794 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Max_C": {
-                    "value": "3.5 mol/kg",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                }
-            },
-            "molar_volume_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "V_o": null,
-                "Max_C": null
-            },
-            "viscosity_jones_dole": {
-                "B": null
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -2117,6 +2047,111 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "BaH6(CO)4(aq)",
+        "charge": 0,
+        "molecular_weight": "255.41504 g/mol",
+        "elements": [
+            "Ba",
+            "C",
+            "H",
+            "O"
+        ],
+        "chemsys": "Ba-C-H-O",
+        "pmg_ion": {
+            "Ba": 1,
+            "C": 4,
+            "H": 6,
+            "O": 4,
+            "charge": 0,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "BaH<sub>6</sub>(CO)<sub>4</sub>",
+        "formula_latex": "BaH$_{6}$(CO)$_{4}$",
+        "formula_hill": "C4 H6 Ba O4",
+        "formula_pretty": "BaH6(CO)4",
+        "oxi_state_guesses": {
+            "Ba": 2,
+            "C": 0,
+            "H": 1,
+            "O": -2
+        },
+        "n_atoms": 15,
+        "n_elements": 4,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "2.68 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": {
+                    "value": "0.2437 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "1.093 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "-0.03794 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "3.5 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -2206,6 +2241,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -2293,6 +2333,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             },
             "dielectric_zuber": {
                 "value": "0.75 dimensionless",
@@ -2390,6 +2435,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -2464,6 +2514,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -2539,6 +2594,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -2629,6 +2689,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -2699,6 +2764,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -2791,6 +2861,11 @@
                     "data_type": "fitted"
                 }
             },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            },
             "dielectric_zuber": {
                 "value": "7.31 dimensionless",
                 "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
@@ -2868,82 +2943,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
-            }
-        }
-    },
-    {
-        "formula": "CH3COO[-1]",
-        "charge": -1,
-        "molecular_weight": "59.04402 g/mol",
-        "elements": [
-            "C",
-            "H",
-            "O"
-        ],
-        "chemsys": "C-H-O",
-        "pmg_ion": {
-            "C": 2,
-            "H": 3,
-            "O": 2,
-            "charge": -1,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "CH<sub>3</sub>COO<sup>-1</sup>",
-        "formula_latex": "CH$_{3}$COO$^{-1}$",
-        "formula_hill": "C2 H3 O2",
-        "formula_pretty": "CH3COO^-1",
-        "oxi_state_guesses": {
-            "C": 0,
-            "H": 1,
-            "O": -2
-        },
-        "n_atoms": 7,
-        "n_elements": 3,
-        "size": {
-            "radius_ionic": {
-                "value": "None",
-                "reference": "pymatgen",
-                "data_type": "experimental"
             },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "1.7 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null
-        },
-        "thermo": {
-            "ΔG_hydration": null,
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": {
-                "value": "1.089e-05 cm**2/s",
-                "reference": "CRC",
-                "data_type": "experimental"
-            }
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "Max_C": null
-            },
-            "molar_volume_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "V_o": null,
-                "Max_C": null
-            },
-            "viscosity_jones_dole": {
-                "B": null
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -3020,38 +3024,43 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
     {
-        "formula": "CNO[-1]",
+        "formula": "CH3COO[-1]",
         "charge": -1,
-        "molecular_weight": "42.0168 g/mol",
+        "molecular_weight": "59.04402 g/mol",
         "elements": [
             "C",
-            "N",
+            "H",
             "O"
         ],
-        "chemsys": "C-N-O",
+        "chemsys": "C-H-O",
         "pmg_ion": {
-            "C": 1,
-            "N": 1,
-            "O": 1,
+            "C": 2,
+            "H": 3,
+            "O": 2,
             "charge": -1,
             "@module": "pymatgen.core.ion",
             "@class": "Ion",
             "@version": null
         },
-        "formula_html": "CNO<sup>-1</sup>",
-        "formula_latex": "CNO$^{-1}$",
-        "formula_hill": "C N O",
-        "formula_pretty": "CNO^-1",
+        "formula_html": "CH<sub>3</sub>COO<sup>-1</sup>",
+        "formula_latex": "CH$_{3}$COO$^{-1}$",
+        "formula_hill": "C2 H3 O2",
+        "formula_pretty": "CH3COO^-1",
         "oxi_state_guesses": {
-            "C": 4,
-            "N": -3,
+            "C": 0,
+            "H": 1,
             "O": -2
         },
-        "n_atoms": 3,
+        "n_atoms": 7,
         "n_elements": 3,
         "size": {
             "radius_ionic": {
@@ -3073,7 +3082,7 @@
         },
         "transport": {
             "diffusion_coefficient": {
-                "value": "1.72e-05 cm**2/s",
+                "value": "1.089e-05 cm**2/s",
                 "reference": "CRC",
                 "data_type": "experimental"
             }
@@ -3096,6 +3105,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -3172,6 +3186,92 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "CNO[-1]",
+        "charge": -1,
+        "molecular_weight": "42.0168 g/mol",
+        "elements": [
+            "C",
+            "N",
+            "O"
+        ],
+        "chemsys": "C-N-O",
+        "pmg_ion": {
+            "C": 1,
+            "N": 1,
+            "O": 1,
+            "charge": -1,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "CNO<sup>-1</sup>",
+        "formula_latex": "CNO$^{-1}$",
+        "formula_hill": "C N O",
+        "formula_pretty": "CNO^-1",
+        "oxi_state_guesses": {
+            "C": 4,
+            "N": -3,
+            "O": -2
+        },
+        "n_atoms": 3,
+        "n_elements": 3,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "1.7 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": {
+                "value": "1.72e-05 cm**2/s",
+                "reference": "CRC",
+                "data_type": "experimental"
+            }
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "Max_C": null
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -3256,6 +3356,97 @@
                 "B": {
                     "value": "-0.024 dm**3/mol",
                     "reference": "https://doi.org/10.1021/cr00040a004",
+                    "data_type": "fitted"
+                }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "CO32[-1]",
+        "charge": -1,
+        "molecular_weight": "523.9915 g/mol",
+        "elements": [
+            "C",
+            "O"
+        ],
+        "chemsys": "C-O",
+        "pmg_ion": {
+            "C": 1,
+            "O": 32,
+            "charge": -1,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "CO<sub>32</sub><sup>-1</sup>",
+        "formula_latex": "CO$_{32}$$^{-1}$",
+        "formula_hill": "C O32",
+        "formula_pretty": "CO32^-1",
+        "oxi_state_guesses": {
+            "C": 4,
+            "O": -0.15625
+        },
+        "n_atoms": 33,
+        "n_elements": 2,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "1.7 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "Max_C": null
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "1.12 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "2.84 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
                     "data_type": "fitted"
                 }
             }
@@ -3352,6 +3543,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -3441,6 +3637,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -3517,6 +3718,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -3609,6 +3815,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -3725,6 +3936,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -3838,6 +4054,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -3951,6 +4172,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -4040,6 +4266,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -4131,6 +4362,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             },
             "dielectric_zuber": {
                 "value": "-0.53 dimensionless",
@@ -4228,6 +4464,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -4320,6 +4561,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -4436,6 +4682,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -4552,6 +4803,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -4639,6 +4895,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -4728,6 +4989,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -4815,6 +5081,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -4890,6 +5161,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -4963,6 +5239,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -5044,6 +5325,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -5134,6 +5420,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -5226,6 +5517,23 @@
                     "data_type": "fitted"
                 }
             },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "1.6 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "6.9 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "194 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                }
+            },
             "dielectric_zuber": {
                 "value": "6.8 dimensionless",
                 "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
@@ -5310,6 +5618,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -5386,6 +5699,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -5502,6 +5820,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -5591,6 +5914,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -5704,6 +6032,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -5793,6 +6126,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -5880,6 +6218,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -5955,6 +6298,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -6047,6 +6395,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -6136,6 +6489,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -6226,6 +6584,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -6301,6 +6664,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -6388,6 +6756,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -6504,6 +6877,136 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "Cs2SO4(aq)",
+        "charge": 0,
+        "molecular_weight": "361.8735038 g/mol",
+        "elements": [
+            "Cs",
+            "S",
+            "O"
+        ],
+        "chemsys": "Cs-O-S",
+        "pmg_ion": {
+            "Cs": 2,
+            "S": 1,
+            "O": 4,
+            "charge": 0,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "Cs<sub>2</sub>SO<sub>4</sub>",
+        "formula_latex": "Cs$_{2}$SO$_{4}$",
+        "formula_hill": "Cs2 O4 S",
+        "formula_pretty": "Cs2SO4",
+        "oxi_state_guesses": {
+            "Cs": 1,
+            "S": 6,
+            "O": -2
+        },
+        "n_atoms": 7,
+        "n_elements": 3,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "3.43 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": {
+                "value": "-1394.0 ± 10 kJ/mol",
+                "reference": "10.1021/acs.jpca.9b05140",
+                "data_type": "experimental"
+            },
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": {
+                    "value": "0.1009 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "0.9094 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "-0.0087 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "4.0 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "molar_volume_pitzer": {
+                "Beta0": {
+                    "value": "0.0007906 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "0.002396 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "-1.989e-05 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "V_o": {
+                    "value": "40.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "3.816 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -6617,6 +7120,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -6730,6 +7238,133 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "CsCl(aq)",
+        "charge": 0,
+        "molecular_weight": "168.3584519 g/mol",
+        "elements": [
+            "Cs",
+            "Cl"
+        ],
+        "chemsys": "Cl-Cs",
+        "pmg_ion": {
+            "Cs": 1,
+            "Cl": 1,
+            "charge": 0,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "CsCl",
+        "formula_latex": "CsCl",
+        "formula_hill": "Cl Cs",
+        "formula_pretty": "CsCl",
+        "oxi_state_guesses": {
+            "Cs": 1,
+            "Cl": -1
+        },
+        "n_atoms": 2,
+        "n_elements": 2,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "3.43 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": {
+                "value": "nan ± 6 kJ/mol",
+                "reference": "Marcus2015",
+                "data_type": "experimental"
+            },
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": {
+                    "value": "0.03745 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "0.02709 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "-0.00103 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "11.0 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "molar_volume_pitzer": {
+                "Beta0": {
+                    "value": "8.174e-05 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "0.0004061 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "-7.6e-06 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "V_o": {
+                    "value": "39.1 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "10.6 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -6843,11 +7478,16 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
     {
-        "formula": "CsHC2O.1H2O(aq)",
+        "formula": "CsH3(CO)2(aq)",
         "charge": 0,
         "molecular_weight": "191.9494719 g/mol",
         "elements": [
@@ -6867,10 +7507,10 @@
             "@class": "Ion",
             "@version": null
         },
-        "formula_html": "CsHC<sub>2</sub>O<sub>.1</sub>H<sub>2</sub>O",
-        "formula_latex": "CsHC$_{2}$O$_{.1}$H$_{2}$O",
+        "formula_html": "CsH<sub>3</sub>(CO)<sub>2</sub>",
+        "formula_latex": "CsH$_{3}$(CO)$_{2}$",
         "formula_hill": "C2 H3 Cs O2",
-        "formula_pretty": "CsHC2O.1H2O",
+        "formula_pretty": "CsH3(CO)2",
         "oxi_state_guesses": {
             "Cs": 1,
             "C": 0,
@@ -6938,6 +7578,116 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "CsH3(CO)2(aq)",
+        "charge": 0,
+        "molecular_weight": "191.9494719 g/mol",
+        "elements": [
+            "Cs",
+            "C",
+            "H",
+            "O"
+        ],
+        "chemsys": "C-Cs-H-O",
+        "pmg_ion": {
+            "Cs": 1,
+            "C": 2,
+            "H": 3,
+            "O": 2,
+            "charge": 0,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "CsH<sub>3</sub>(CO)<sub>2</sub>",
+        "formula_latex": "CsH$_{3}$(CO)$_{2}$",
+        "formula_hill": "C2 H3 Cs O2",
+        "formula_pretty": "CsH3(CO)2",
+        "oxi_state_guesses": {
+            "Cs": 1,
+            "C": 0,
+            "H": 1,
+            "O": -2
+        },
+        "n_atoms": 8,
+        "n_elements": 4,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "3.43 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": {
+                    "value": "0.1674 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "0.3399 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "-0.00671 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "3.5 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            },
+            "dielectric_zuber": {
+                "value": "8.48 dimensionless",
+                "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
+                "data_type": "fitted"
             }
         }
     },
@@ -7051,6 +7801,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -7143,6 +7898,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -7259,6 +8019,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -7351,6 +8116,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -7438,6 +8208,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             },
             "dielectric_zuber": {
                 "value": "2.23 dimensionless",
@@ -7559,6 +8334,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -7672,6 +8452,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -7788,6 +8573,136 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "CuSO4(aq)",
+        "charge": 0,
+        "molecular_weight": "159.6086 g/mol",
+        "elements": [
+            "Cu",
+            "S",
+            "O"
+        ],
+        "chemsys": "Cu-O-S",
+        "pmg_ion": {
+            "Cu": 1,
+            "S": 1,
+            "O": 4,
+            "charge": 0,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "CuSO<sub>4</sub>",
+        "formula_latex": "CuSO$_{4}$",
+        "formula_hill": "Cu O4 S",
+        "formula_pretty": "CuSO4",
+        "oxi_state_guesses": {
+            "Cu": 2,
+            "S": 6,
+            "O": -2
+        },
+        "n_atoms": 6,
+        "n_elements": 3,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "1.96 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": {
+                "value": "nan ± 6 kJ/mol",
+                "reference": "Marcus2015",
+                "data_type": "experimental"
+            },
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": {
+                    "value": "0.2281 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "2.505 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "-50.28 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "0.005787 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "1.42 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "molar_volume_pitzer": {
+                "Beta0": {
+                    "value": "0.001499 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "-0.008124 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.2203 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "-0.0002589 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "V_o": {
+                    "value": "-6.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "1.418 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -7863,6 +8778,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -7954,6 +8874,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -8024,6 +8949,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -8094,6 +9024,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -8177,6 +9112,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -8260,113 +9200,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
-            }
-        }
-    },
-    {
-        "formula": "Er[+3]",
-        "charge": 3,
-        "molecular_weight": "167.259 g/mol",
-        "elements": [
-            "Er"
-        ],
-        "chemsys": "Er",
-        "pmg_ion": {
-            "Er": 1,
-            "charge": 3,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "Er<sup>+3</sup>",
-        "formula_latex": "Er$^{+3}$",
-        "formula_hill": "Er",
-        "formula_pretty": "Er^+3",
-        "oxi_state_guesses": {
-            "Er": 3
-        },
-        "n_atoms": 1,
-        "n_elements": 1,
-        "size": {
-            "radius_ionic": {
-                "value": "1.03 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
             },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "2.29 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null,
-            "radius_ionic_marcus": {
-                "value": "1.04 ± 0.01 Å",
-                "reference": "10.1021/ic200260r",
-                "data_type": "experimental"
-            }
-        },
-        "thermo": {
-            "ΔG_hydration": {
-                "value": "-3627.0 ± 10 kJ/mol",
-                "reference": "10.1021/acs.jpca.9b05140",
-                "data_type": "experimental"
-            },
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": {
-                "value": "5.85e-06 cm**2/s",
-                "reference": "CRC",
-                "data_type": "experimental"
-            }
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "Max_C": null
-            },
-            "molar_volume_pitzer": {
-                "Beta0": {
-                    "value": "2.655e-05 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta1": {
-                    "value": "0.000352 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta2": {
-                    "value": "0.0 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Cphi": {
-                    "value": "1.061e-05 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "V_o": {
-                    "value": "33.7 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Max_C": {
-                    "value": "5.15 mol/kg",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                }
-            },
-            "viscosity_jones_dole": {
-                "B": {
-                    "value": "0.657 dm**3/mol",
-                    "reference": "https://doi.org/10.1021/cr00040a004",
-                    "data_type": "fitted"
-                }
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -8459,6 +9297,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -8572,6 +9415,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -8642,6 +9490,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -8725,6 +9578,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -8816,6 +9674,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             },
             "dielectric_zuber": {
                 "value": "5.88 dimensionless",
@@ -8910,6 +9773,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -9003,6 +9871,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -9116,6 +9989,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -9229,6 +10107,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -9320,97 +10203,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
-            }
-        }
-    },
-    {
-        "formula": "Fe[+2]",
-        "charge": 2,
-        "molecular_weight": "55.845 g/mol",
-        "elements": [
-            "Fe"
-        ],
-        "chemsys": "Fe",
-        "pmg_ion": {
-            "Fe": 1,
-            "charge": 2,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "Fe<sup>+2</sup>",
-        "formula_latex": "Fe$^{+2}$",
-        "formula_hill": "Fe",
-        "formula_pretty": "Fe^+2",
-        "oxi_state_guesses": {
-            "Fe": 2
-        },
-        "n_atoms": 1,
-        "n_elements": 1,
-        "size": {
-            "radius_ionic": {
-                "value": "0.92 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
             },
-            "radius_hydrated": {
-                "value": "4.28 Å",
-                "reference": "Nightingale1959",
-                "data_type": "experimental"
-            },
-            "radius_vdw": {
-                "value": "2.04 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": {
-                "value": "-32.3 cm**3/mol",
-                "reference": "Calculation of the Partial Molal Volume of Organic Compounds and Polymers. Progress in Colloid & Polymer Science (94), 20-39.",
-                "data_type": "experimental"
-            },
-            "radius_ionic_marcus": {
-                "value": "0.78 ± 0.02 Å",
-                "reference": "Marcus2015",
-                "data_type": "experimental"
-            }
-        },
-        "thermo": {
-            "ΔG_hydration": {
-                "value": "-1561.0 ± 10 kJ/mol",
-                "reference": "10.1021/acs.jpca.9b05140",
-                "data_type": "experimental"
-            },
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": {
-                "value": "7.19e-06 cm**2/s",
-                "reference": "CRC",
-                "data_type": "experimental"
-            }
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "Max_C": null
-            },
-            "molar_volume_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "V_o": null,
-                "Max_C": null
-            },
-            "viscosity_jones_dole": {
-                "B": {
-                    "value": "0.412 dm**3/mol",
-                    "reference": "https://doi.org/10.1021/cr00040a004",
-                    "data_type": "fitted"
-                }
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -9502,6 +10299,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -9577,6 +10379,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -9690,6 +10497,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -9773,6 +10585,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -9843,6 +10660,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -9919,6 +10741,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -9940,11 +10767,10 @@
         "formula_latex": "H$_{2}$O",
         "formula_hill": "H2 O",
         "formula_pretty": "H2O",
-        "oxi_state_guesses":
-            {
-                "H": 1,
-                "O": -2
-            },
+        "oxi_state_guesses": {
+            "H": 1,
+            "O": -2
+        },
         "n_atoms": 3,
         "n_elements": 2,
         "size": {
@@ -9978,6 +10804,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -10057,6 +10888,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -10133,6 +10969,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -10215,6 +11056,98 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "H3O[+1]",
+        "charge": 1,
+        "molecular_weight": "19.02322 g/mol",
+        "elements": [
+            "H",
+            "O"
+        ],
+        "chemsys": "H-O",
+        "pmg_ion": {
+            "H": 3,
+            "O": 1,
+            "charge": 1,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "H<sub>3</sub>O<sup>+1</sup>",
+        "formula_latex": "H$_{3}$O$^{+1}$",
+        "formula_hill": "H3 O",
+        "formula_pretty": "H3O^+1",
+        "oxi_state_guesses": {
+            "H": 1,
+            "O": -2
+        },
+        "n_atoms": 4,
+        "n_elements": 2,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": {
+                "value": "2.82 Å",
+                "reference": "Nightingale1959",
+                "data_type": "experimental"
+            },
+            "radius_vdw": {
+                "value": "1.1 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null,
+            "radius_ionic_marcus": {
+                "value": "1.3 ± 0.02 Å",
+                "reference": "Marcus2015",
+                "data_type": "experimental"
+            }
+        },
+        "thermo": {
+            "ΔG_hydration": {
+                "value": "-1561.0 ± 10 kJ/mol",
+                "reference": "10.1021/acs.jpca.9b05140",
+                "data_type": "experimental"
+            },
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "Max_C": null
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -10331,6 +11264,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -10447,6 +11385,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -10563,6 +11506,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -10679,6 +11627,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -10798,6 +11751,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -10890,6 +11848,23 @@
                 "B": {
                     "value": "-0.008 dm**3/mol",
                     "reference": "https://doi.org/10.1021/cr00040a004",
+                    "data_type": "fitted"
+                }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "0.95 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "4.53 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "312 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
                     "data_type": "fitted"
                 }
             }
@@ -10991,6 +11966,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -11067,6 +12047,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -11140,6 +12125,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -11235,6 +12225,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -11348,6 +12343,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -11433,6 +12433,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -11522,6 +12527,23 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "1.43 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                }
             }
         }
     },
@@ -11635,6 +12657,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -11751,6 +12778,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -11824,6 +12856,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -11937,6 +12974,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -12057,6 +13099,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -12135,6 +13182,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -12211,6 +13263,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -12287,6 +13344,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -12372,6 +13434,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -12449,6 +13516,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -12525,6 +13597,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -12608,6 +13685,23 @@
                     "data_type": "fitted"
                 }
             },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "0.46 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "763 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                }
+            },
             "dielectric_zuber": {
                 "value": "9.55 dimensionless",
                 "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
@@ -12687,6 +13781,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -12766,6 +13865,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -12849,6 +13953,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -12939,6 +14048,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -13016,6 +14130,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -13108,6 +14227,11 @@
                     "data_type": "fitted"
                 }
             },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            },
             "dielectric_zuber": {
                 "value": "7.65 dimensionless",
                 "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
@@ -13182,6 +14306,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -13252,6 +14381,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -13327,6 +14461,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -13400,6 +14539,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -13470,6 +14614,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -13586,6 +14735,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -13705,6 +14859,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -13821,6 +14980,144 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "K2SO4(aq)",
+        "charge": 0,
+        "molecular_weight": "174.2592 g/mol",
+        "elements": [
+            "K",
+            "S",
+            "O"
+        ],
+        "chemsys": "K-O-S",
+        "pmg_ion": {
+            "K": 2,
+            "S": 1,
+            "O": 4,
+            "charge": 0,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "K<sub>2</sub>SO<sub>4</sub>",
+        "formula_latex": "K$_{2}$SO$_{4}$",
+        "formula_hill": "K2 O4 S",
+        "formula_pretty": "K2SO4",
+        "oxi_state_guesses": {
+            "K": 1,
+            "S": 6,
+            "O": -2
+        },
+        "n_atoms": 7,
+        "n_elements": 3,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "2.75 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": {
+                    "value": "0.07424 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "0.5188 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "-0.01057 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "2.0 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "molar_volume_pitzer": {
+                "Beta0": {
+                    "value": "-0.001179 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "0.006263 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "0.001473 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "V_o": {
+                    "value": "32.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "1.05 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "3.4 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "24.6 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "97 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                }
             }
         }
     },
@@ -13916,6 +15213,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -14032,6 +15334,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -14127,6 +15434,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -14207,79 +15519,13 @@
                 }
             },
             "molar_volume_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "V_o": null,
-                "Max_C": null
-            },
-            "viscosity_jones_dole": {
-                "B": null
-            }
-        }
-    },
-    {
-        "formula": "KBr(aq)",
-        "charge": 0,
-        "molecular_weight": "119.00229999999999 g/mol",
-        "elements": [
-            "K",
-            "Br"
-        ],
-        "chemsys": "Br-K",
-        "pmg_ion": {
-            "K": 1,
-            "Br": 1,
-            "charge": 0,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "KBr",
-        "formula_latex": "KBr",
-        "formula_hill": "Br K",
-        "formula_pretty": "KBr",
-        "oxi_state_guesses": {
-            "K": 1,
-            "Br": -1
-        },
-        "n_atoms": 2,
-        "n_elements": 2,
-        "size": {
-            "radius_ionic": {
-                "value": "None",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "2.75 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null
-        },
-        "thermo": {
-            "ΔG_hydration": null,
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": {
-                "value": "9.05e-06 cm**2/s",
-                "reference": "CRC",
-                "data_type": "experimental"
-            }
-        },
-        "model_parameters": {
-            "activity_pitzer": {
                 "Beta0": {
-                    "value": "0.05517 dimensionless",
+                    "value": "2.655e-05 dimensionless",
                     "reference": "10.1021/je2009329",
                     "data_type": "fitted"
                 },
                 "Beta1": {
-                    "value": "0.2361 dimensionless",
+                    "value": "0.000352 dimensionless",
                     "reference": "10.1021/je2009329",
                     "data_type": "fitted"
                 },
@@ -14289,26 +15535,28 @@
                     "data_type": "fitted"
                 },
                 "Cphi": {
-                    "value": "-0.00148 dimensionless",
+                    "value": "1.061e-05 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "V_o": {
+                    "value": "33.7 dimensionless",
                     "reference": "10.1021/je2009329",
                     "data_type": "fitted"
                 },
                 "Max_C": {
-                    "value": "5.5 mol/kg",
+                    "value": "5.15 mol/kg",
                     "reference": "10.1021/je2009329",
                     "data_type": "fitted"
                 }
             },
-            "molar_volume_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "V_o": null,
-                "Max_C": null
-            },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -14401,6 +15649,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -14520,6 +15773,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -14609,6 +15867,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -14701,6 +15964,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -14797,6 +16065,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -14913,6 +16186,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -15026,11 +16304,16 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
     {
-        "formula": "KHC2O.1H2O(aq)",
+        "formula": "KH3(CO)2(aq)",
         "charge": 0,
         "molecular_weight": "98.14232 g/mol",
         "elements": [
@@ -15050,10 +16333,10 @@
             "@class": "Ion",
             "@version": null
         },
-        "formula_html": "KHC<sub>2</sub>O<sub>.1</sub>H<sub>2</sub>O",
-        "formula_latex": "KHC$_{2}$O$_{.1}$H$_{2}$O",
+        "formula_html": "KH<sub>3</sub>(CO)<sub>2</sub>",
+        "formula_latex": "KH$_{3}$(CO)$_{2}$",
         "formula_hill": "C2 H3 K O2",
-        "formula_pretty": "KHC2O.1H2O",
+        "formula_pretty": "KH3(CO)2",
         "oxi_state_guesses": {
             "K": 1,
             "C": 0,
@@ -15145,6 +16428,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -15264,6 +16552,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -15377,6 +16670,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -15493,6 +16791,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -15609,6 +16912,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -15725,11 +17033,16 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
     {
-        "formula": "KPO3.1H2O(aq)",
+        "formula": "KP(HO2)2(aq)",
         "charge": 0,
         "molecular_weight": "136.085542 g/mol",
         "elements": [
@@ -15749,10 +17062,10 @@
             "@class": "Ion",
             "@version": null
         },
-        "formula_html": "KPO<sub>3.1</sub>H<sub>2</sub>O",
-        "formula_latex": "KPO$_{3.1}$H$_{2}$O",
+        "formula_html": "KP(HO<sub>2</sub>)<sub>2</sub>",
+        "formula_latex": "KP(HO$_{2}$)$_{2}$",
         "formula_hill": "H2 K O4 P",
-        "formula_pretty": "KPO3.1H2O",
+        "formula_pretty": "KP(HO2)2",
         "oxi_state_guesses": {
             "K": 1,
             "H": 1,
@@ -15844,6 +17157,100 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "KSO4[-1]",
+        "charge": -1,
+        "molecular_weight": "135.1609 g/mol",
+        "elements": [
+            "K",
+            "S",
+            "O"
+        ],
+        "chemsys": "K-O-S",
+        "pmg_ion": {
+            "K": 1,
+            "S": 1,
+            "O": 4,
+            "charge": -1,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "KSO<sub>4</sub><sup>-1</sup>",
+        "formula_latex": "KSO$_{4}$$^{-1}$",
+        "formula_hill": "K O4 S",
+        "formula_pretty": "KSO4^-1",
+        "oxi_state_guesses": {
+            "K": 1,
+            "S": 6,
+            "O": -2
+        },
+        "n_atoms": 6,
+        "n_elements": 3,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "2.75 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "Max_C": null
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                }
             }
         }
     },
@@ -15933,6 +17340,23 @@
                 "B": {
                     "value": "-0.009 dm**3/mol",
                     "reference": "https://doi.org/10.1021/cr00040a004",
+                    "data_type": "fitted"
+                }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "2.5 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "21 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "395 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
                     "data_type": "fitted"
                 }
             },
@@ -16032,6 +17456,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -16145,6 +17574,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -16232,6 +17666,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -16348,6 +17787,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -16461,6 +17905,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -16574,6 +18023,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -16690,11 +18144,16 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
     {
-        "formula": "LiHC2O.1H2O(aq)",
+        "formula": "LiH3(CO)2(aq)",
         "charge": 0,
         "molecular_weight": "65.98501999999999 g/mol",
         "elements": [
@@ -16714,10 +18173,10 @@
             "@class": "Ion",
             "@version": null
         },
-        "formula_html": "LiHC<sub>2</sub>O<sub>.1</sub>H<sub>2</sub>O",
-        "formula_latex": "LiHC$_{2}$O$_{.1}$H$_{2}$O",
+        "formula_html": "LiH<sub>3</sub>(CO)<sub>2</sub>",
+        "formula_latex": "LiH$_{3}$(CO)$_{2}$",
         "formula_hill": "C2 H3 Li O2",
-        "formula_pretty": "LiHC2O.1H2O",
+        "formula_pretty": "LiH3(CO)2",
         "oxi_state_guesses": {
             "Li": 1,
             "C": 0,
@@ -16809,6 +18268,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -16922,6 +18386,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -17014,6 +18483,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -17130,6 +18604,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -17246,6 +18725,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -17338,6 +18822,11 @@
                     "data_type": "fitted"
                 }
             },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            },
             "dielectric_zuber": {
                 "value": "6.59 dimensionless",
                 "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
@@ -17421,6 +18910,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -17537,6 +19031,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -17653,6 +19152,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -17766,248 +19270,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
-            }
-        }
-    },
-    {
-        "formula": "MgC4O.3H2O(aq)",
-        "charge": 0,
-        "molecular_weight": "142.39304 g/mol",
-        "elements": [
-            "Mg",
-            "C",
-            "H",
-            "O"
-        ],
-        "chemsys": "C-H-Mg-O",
-        "pmg_ion": {
-            "Mg": 1,
-            "C": 4,
-            "H": 6,
-            "O": 4,
-            "charge": 0,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "MgC<sub>4</sub>O<sub>.3</sub>H<sub>2</sub>O",
-        "formula_latex": "MgC$_{4}$O$_{.3}$H$_{2}$O",
-        "formula_hill": "C4 H6 Mg O4",
-        "formula_pretty": "MgC4O.3H2O",
-        "oxi_state_guesses": {
-            "Mg": 2,
-            "C": 0,
-            "H": 1,
-            "O": -2
-        },
-        "n_atoms": 15,
-        "n_elements": 4,
-        "size": {
-            "radius_ionic": {
-                "value": "None",
-                "reference": "pymatgen",
-                "data_type": "experimental"
             },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "1.73 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null
-        },
-        "thermo": {
-            "ΔG_hydration": null,
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": null
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": {
-                    "value": "0.21 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta1": {
-                    "value": "0.9347 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta2": {
-                    "value": "0.0 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Cphi": {
-                    "value": "-0.01332 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Max_C": {
-                    "value": "4.0 mol/kg",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                }
-            },
-            "molar_volume_pitzer": {
-                "Beta0": {
-                    "value": "0.0006679 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta1": {
-                    "value": "-0.0002526 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta2": {
-                    "value": "0.0 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Cphi": {
-                    "value": "0.0001019 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "V_o": {
-                    "value": "60.2 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Max_C": {
-                    "value": "0.573 mol/kg",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                }
-            },
-            "viscosity_jones_dole": {
-                "B": null
-            }
-        }
-    },
-    {
-        "formula": "MgC4O.3H2O(aq)",
-        "charge": 0,
-        "molecular_weight": "142.39304 g/mol",
-        "elements": [
-            "Mg",
-            "C",
-            "H",
-            "O"
-        ],
-        "chemsys": "C-H-Mg-O",
-        "pmg_ion": {
-            "Mg": 1,
-            "C": 4,
-            "H": 6,
-            "O": 4,
-            "charge": 0,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "MgC<sub>4</sub>O<sub>.3</sub>H<sub>2</sub>O",
-        "formula_latex": "MgC$_{4}$O$_{.3}$H$_{2}$O",
-        "formula_hill": "C4 H6 Mg O4",
-        "formula_pretty": "MgC4O.3H2O",
-        "oxi_state_guesses": {
-            "Mg": 2,
-            "C": 0,
-            "H": 1,
-            "O": -2
-        },
-        "n_atoms": 15,
-        "n_elements": 4,
-        "size": {
-            "radius_ionic": {
-                "value": "None",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "1.73 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null
-        },
-        "thermo": {
-            "ΔG_hydration": {
-                "value": "-1394.0 ± 10 kJ/mol",
-                "reference": "10.1021/acs.jpca.9b05140",
-                "data_type": "experimental"
-            },
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": null
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": {
-                    "value": "0.21 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta1": {
-                    "value": "0.9347 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta2": {
-                    "value": "0.0 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Cphi": {
-                    "value": "-0.01332 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Max_C": {
-                    "value": "4.0 mol/kg",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                }
-            },
-            "molar_volume_pitzer": {
-                "Beta0": {
-                    "value": "0.0006679 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta1": {
-                    "value": "-0.0002526 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta2": {
-                    "value": "0.0 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Cphi": {
-                    "value": "0.0001019 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "V_o": {
-                    "value": "60.2 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Max_C": {
-                    "value": "0.573 mol/kg",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                }
-            },
-            "viscosity_jones_dole": {
-                "B": null
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -18121,6 +19388,135 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "MgH6(CO)4(aq)",
+        "charge": 0,
+        "molecular_weight": "142.39304 g/mol",
+        "elements": [
+            "Mg",
+            "C",
+            "H",
+            "O"
+        ],
+        "chemsys": "C-H-Mg-O",
+        "pmg_ion": {
+            "Mg": 1,
+            "C": 4,
+            "H": 6,
+            "O": 4,
+            "charge": 0,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "MgH<sub>6</sub>(CO)<sub>4</sub>",
+        "formula_latex": "MgH$_{6}$(CO)$_{4}$",
+        "formula_hill": "C4 H6 Mg O4",
+        "formula_pretty": "MgH6(CO)4",
+        "oxi_state_guesses": {
+            "Mg": 2,
+            "C": 0,
+            "H": 1,
+            "O": -2
+        },
+        "n_atoms": 15,
+        "n_elements": 4,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "1.73 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": {
+                    "value": "0.21 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "0.9347 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "-0.01332 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "4.0 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "molar_volume_pitzer": {
+                "Beta0": {
+                    "value": "0.0006679 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "-0.0002526 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "0.0001019 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "V_o": {
+                    "value": "60.2 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "0.573 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -18234,6 +19630,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -18350,6 +19751,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -18441,6 +19847,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             },
             "dielectric_zuber": {
                 "value": "6.69 dimensionless",
@@ -18559,6 +19970,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -18649,6 +20065,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -18765,6 +20186,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -18856,6 +20282,107 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "Mn[+2]",
+        "charge": 2,
+        "molecular_weight": "54.938045 g/mol",
+        "elements": [
+            "Mn"
+        ],
+        "chemsys": "Mn",
+        "pmg_ion": {
+            "Mn": 1,
+            "charge": 2,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "Mn<sup>+2</sup>",
+        "formula_latex": "Mn$^{+2}$",
+        "formula_hill": "Mn",
+        "formula_pretty": "Mn^+2",
+        "oxi_state_guesses": {
+            "Mn": 2
+        },
+        "n_atoms": 1,
+        "n_elements": 1,
+        "size": {
+            "radius_ionic": {
+                "value": "0.97 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": {
+                "value": "4.38 Å",
+                "reference": "Nightingale1959",
+                "data_type": "experimental"
+            },
+            "radius_vdw": {
+                "value": "2.05 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": {
+                "value": "-25.3 cm**3/mol",
+                "reference": "Calculation of the Partial Molal Volume of Organic Compounds and Polymers. Progress in Colloid & Polymer Science (94), 20-39.",
+                "data_type": "experimental"
+            },
+            "radius_ionic_marcus": {
+                "value": "0.83 ± 0.02 Å",
+                "reference": "Marcus2015",
+                "data_type": "experimental"
+            }
+        },
+        "thermo": {
+            "ΔG_hydration": {
+                "value": "-1489.0 ± 10 kJ/mol",
+                "reference": "10.1021/acs.jpca.9b05140",
+                "data_type": "experimental"
+            },
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": {
+                "value": "7.12e-06 cm**2/s",
+                "reference": "CRC",
+                "data_type": "experimental"
+            }
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "Max_C": null
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": {
+                    "value": "0.388 dm**3/mol",
+                    "reference": "https://doi.org/10.1021/cr00040a004",
+                    "data_type": "fitted"
+                }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -18926,6 +20453,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -19012,6 +20544,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -19082,6 +20619,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -19164,6 +20706,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -19259,6 +20806,23 @@
                     "data_type": "fitted"
                 }
             },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "1.85 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "3.85 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "184 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                }
+            },
             "dielectric_zuber": {
                 "value": "6.75 dimensionless",
                 "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
@@ -19337,6 +20901,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -19453,6 +21022,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -19572,6 +21146,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -19688,6 +21267,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -19804,6 +21388,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -19920,126 +21509,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
-            }
-        }
-    },
-    {
-        "formula": "Na3PO4(aq)",
-        "charge": 0,
-        "molecular_weight": "163.94066984 g/mol",
-        "elements": [
-            "Na",
-            "P",
-            "O"
-        ],
-        "chemsys": "Na-O-P",
-        "pmg_ion": {
-            "Na": 3,
-            "P": 1,
-            "O": 4,
-            "charge": 0,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "Na<sub>3</sub>PO<sub>4</sub>",
-        "formula_latex": "Na$_{3}$PO$_{4}$",
-        "formula_hill": "Na3 O4 P",
-        "formula_pretty": "Na3PO4",
-        "oxi_state_guesses": {
-            "Na": 1,
-            "P": 5,
-            "O": -2
-        },
-        "n_atoms": 8,
-        "n_elements": 3,
-        "size": {
-            "radius_ionic": {
-                "value": "None",
-                "reference": "pymatgen",
-                "data_type": "experimental"
             },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "2.27 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null
-        },
-        "thermo": {
-            "ΔG_hydration": null,
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": {
-                "value": "nan cm**2/s",
-                "reference": "CRC",
-                "data_type": "experimental"
-            }
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": {
-                    "value": "0.139 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta1": {
-                    "value": "5.419 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta2": {
-                    "value": "0.0 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Cphi": {
-                    "value": "-0.04454 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Max_C": {
-                    "value": "0.8 mol/kg",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                }
-            },
-            "molar_volume_pitzer": {
-                "Beta0": {
-                    "value": "-0.002545 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta1": {
-                    "value": "0.01227 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta2": {
-                    "value": "0.0 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Cphi": {
-                    "value": "0.00337 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "V_o": {
-                    "value": "-25.0 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Max_C": {
-                    "value": "0.6657 mol/kg",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                }
-            },
-            "viscosity_jones_dole": {
-                "B": null
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -20153,6 +21627,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -20269,6 +21748,100 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "NaCO3[-1]",
+        "charge": -1,
+        "molecular_weight": "82.99866928 g/mol",
+        "elements": [
+            "Na",
+            "C",
+            "O"
+        ],
+        "chemsys": "C-Na-O",
+        "pmg_ion": {
+            "Na": 1,
+            "C": 1,
+            "O": 3,
+            "charge": -1,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "NaCO<sub>3</sub><sup>-1</sup>",
+        "formula_latex": "NaCO$_{3}$$^{-1}$",
+        "formula_hill": "C Na O3",
+        "formula_pretty": "NaCO3^-1",
+        "oxi_state_guesses": {
+            "Na": 1,
+            "C": 4,
+            "O": -2
+        },
+        "n_atoms": 5,
+        "n_elements": 3,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "2.27 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "Max_C": null
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                }
             }
         }
     },
@@ -20388,6 +21961,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -20501,6 +22079,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -20617,6 +22200,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -20733,6 +22321,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -20846,11 +22439,138 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
     {
-        "formula": "NaHC2O.1H2O(aq)",
+        "formula": "NaF(aq)",
+        "charge": 0,
+        "molecular_weight": "41.98817248 g/mol",
+        "elements": [
+            "Na",
+            "F"
+        ],
+        "chemsys": "F-Na",
+        "pmg_ion": {
+            "Na": 1,
+            "F": 1,
+            "charge": 0,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "NaF",
+        "formula_latex": "NaF",
+        "formula_hill": "F Na",
+        "formula_pretty": "NaF",
+        "oxi_state_guesses": {
+            "Na": 1,
+            "F": -1
+        },
+        "n_atoms": 2,
+        "n_elements": 2,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "2.27 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": {
+                "value": "-1576.0 ± 10 kJ/mol",
+                "reference": "10.1021/acs.jpca.9b05140",
+                "data_type": "experimental"
+            },
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": {
+                    "value": "0.02109 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "0.2183 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "-0.001 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "1.0 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "molar_volume_pitzer": {
+                "Beta0": {
+                    "value": "0.002113 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "-0.003857 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "-0.001535 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "V_o": {
+                    "value": "-2.4 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "0.9923 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "NaH3(CO)2(aq)",
         "charge": 0,
         "molecular_weight": "82.03378928000001 g/mol",
         "elements": [
@@ -20870,10 +22590,10 @@
             "@class": "Ion",
             "@version": null
         },
-        "formula_html": "NaHC<sub>2</sub>O<sub>.1</sub>H<sub>2</sub>O",
-        "formula_latex": "NaHC$_{2}$O$_{.1}$H$_{2}$O",
+        "formula_html": "NaH<sub>3</sub>(CO)<sub>2</sub>",
+        "formula_latex": "NaH$_{3}$(CO)$_{2}$",
         "formula_hill": "C2 H3 Na O2",
-        "formula_pretty": "NaHC2O.1H2O",
+        "formula_pretty": "NaH3(CO)2",
         "oxi_state_guesses": {
             "Na": 1,
             "C": 0,
@@ -20965,11 +22685,16 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
     {
-        "formula": "NaHC3.2H2O(aq)",
+        "formula": "NaH5C3O2(aq)",
         "charge": 0,
         "molecular_weight": "96.06036928 g/mol",
         "elements": [
@@ -20989,10 +22714,10 @@
             "@class": "Ion",
             "@version": null
         },
-        "formula_html": "NaHC<sub>3.2</sub>H<sub>2</sub>O",
-        "formula_latex": "NaHC$_{3.2}$H$_{2}$O",
+        "formula_html": "NaH<sub>5</sub>C<sub>3</sub>O<sub>2</sub>",
+        "formula_latex": "NaH$_{5}$C$_{3}$O$_{2}$",
         "formula_hill": "C3 H5 Na O2",
-        "formula_pretty": "NaHC3.2H2O",
+        "formula_pretty": "NaH5C3O2",
         "oxi_state_guesses": {
             "Na": 1,
             "C": -0.6666666666666666,
@@ -21060,6 +22785,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -21179,6 +22909,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -21298,6 +23033,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -21411,6 +23151,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -21503,6 +23248,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -21619,6 +23369,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -21735,11 +23490,16 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
     {
-        "formula": "NaPO3.1H2O(aq)",
+        "formula": "NaP(HO2)2(aq)",
         "charge": 0,
         "molecular_weight": "119.97701128 g/mol",
         "elements": [
@@ -21759,10 +23519,10 @@
             "@class": "Ion",
             "@version": null
         },
-        "formula_html": "NaPO<sub>3.1</sub>H<sub>2</sub>O",
-        "formula_latex": "NaPO$_{3.1}$H$_{2}$O",
+        "formula_html": "NaP(HO<sub>2</sub>)<sub>2</sub>",
+        "formula_latex": "NaP(HO$_{2}$)$_{2}$",
         "formula_hill": "H2 Na O4 P",
-        "formula_pretty": "NaPO3.1H2O",
+        "formula_pretty": "NaP(HO2)2",
         "oxi_state_guesses": {
             "Na": 1,
             "H": 1,
@@ -21854,6 +23614,100 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "NaSO4[-1]",
+        "charge": -1,
+        "molecular_weight": "119.05236928 g/mol",
+        "elements": [
+            "Na",
+            "S",
+            "O"
+        ],
+        "chemsys": "Na-O-S",
+        "pmg_ion": {
+            "Na": 1,
+            "S": 1,
+            "O": 4,
+            "charge": -1,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "NaSO<sub>4</sub><sup>-1</sup>",
+        "formula_latex": "NaSO$_{4}$$^{-1}$",
+        "formula_hill": "Na O4 S",
+        "formula_pretty": "NaSO4^-1",
+        "oxi_state_guesses": {
+            "Na": 1,
+            "S": 6,
+            "O": -2
+        },
+        "n_atoms": 6,
+        "n_elements": 3,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "2.27 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "Max_C": null
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "0.57 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                }
             }
         }
     },
@@ -21946,6 +23800,23 @@
                     "data_type": "fitted"
                 }
             },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "1.52 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "3.7 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "122 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                }
+            },
             "dielectric_zuber": {
                 "value": "3.62 dimensionless",
                 "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
@@ -22020,6 +23891,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -22112,6 +23988,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -22225,6 +24106,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -22295,6 +24181,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -22378,6 +24269,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -22494,6 +24390,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -22607,6 +24508,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -22723,6 +24629,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -22810,6 +24721,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -22880,6 +24796,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -22950,6 +24871,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -23025,6 +24951,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -23120,6 +25051,23 @@
                     "data_type": "fitted"
                 }
             },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "0.52 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "0 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "553 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                }
+            },
             "dielectric_zuber": {
                 "value": "13.96 dimensionless",
                 "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
@@ -23194,6 +25142,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -23274,6 +25227,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -23355,6 +25313,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -23431,6 +25394,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -23504,6 +25472,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -23577,6 +25550,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -23650,6 +25628,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -23745,6 +25728,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -23834,6 +25822,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -23910,6 +25903,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -23983,6 +25981,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -24065,88 +26068,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
-            }
-        }
-    },
-    {
-        "formula": "PO4[-3]",
-        "charge": -3,
-        "molecular_weight": "94.971362 g/mol",
-        "elements": [
-            "P",
-            "O"
-        ],
-        "chemsys": "O-P",
-        "pmg_ion": {
-            "P": 1,
-            "O": 4,
-            "charge": -3,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "PO<sub>4</sub><sup>-3</sup>",
-        "formula_latex": "PO$_{4}$$^{-3}$",
-        "formula_hill": "O4 P",
-        "formula_pretty": "PO4^-3",
-        "oxi_state_guesses": {
-            "P": 5,
-            "O": -2
-        },
-        "n_atoms": 5,
-        "n_elements": 2,
-        "size": {
-            "radius_ionic": {
-                "value": "None",
-                "reference": "pymatgen",
-                "data_type": "experimental"
             },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "1.8 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null,
-            "radius_ionic_marcus": {
-                "value": "2.38 ± 0.02 Å",
-                "reference": "Marcus2015",
-                "data_type": "experimental"
-            }
-        },
-        "thermo": {
-            "ΔG_hydration": {
-                "value": "nan ± 6 kJ/mol",
-                "reference": "Marcus2015",
-                "data_type": "experimental"
-            },
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": {
-                "value": "8.24e-06 cm**2/s",
-                "reference": "CRC",
-                "data_type": "experimental"
-            }
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "Max_C": null
-            },
-            "molar_volume_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "V_o": null,
-                "Max_C": null
-            },
-            "viscosity_jones_dole": {
-                "B": null
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -24217,6 +26143,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -24309,6 +26240,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -24425,6 +26361,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -24507,6 +26448,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -24582,6 +26528,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -24657,6 +26608,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -24727,6 +26683,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -24840,6 +26801,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -24910,6 +26876,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -24993,6 +26964,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -25068,81 +27044,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
-            }
-        }
-    },
-    {
-        "formula": "Pt[+2]",
-        "charge": 2,
-        "molecular_weight": "195.084 g/mol",
-        "elements": [
-            "Pt"
-        ],
-        "chemsys": "Pt",
-        "pmg_ion": {
-            "Pt": 1,
-            "charge": 2,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "Pt<sup>+2</sup>",
-        "formula_latex": "Pt$^{+2}$",
-        "formula_hill": "Pt",
-        "formula_pretty": "Pt^+2",
-        "oxi_state_guesses": {
-            "Pt": 2
-        },
-        "n_atoms": 1,
-        "n_elements": 1,
-        "size": {
-            "radius_ionic": {
-                "value": "0.94 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
             },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "2.13 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null,
-            "radius_ionic_marcus": {
-                "value": "0.8 ± 0.02 Å",
-                "reference": "Marcus2015",
-                "data_type": "experimental"
-            }
-        },
-        "thermo": {
-            "ΔG_hydration": {
-                "value": "-1489.0 ± 10 kJ/mol",
-                "reference": "10.1021/acs.jpca.9b05140",
-                "data_type": "experimental"
-            },
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": null
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "Max_C": null
-            },
-            "molar_volume_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "V_o": null,
-                "Max_C": null
-            },
-            "viscosity_jones_dole": {
-                "B": null
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -25218,6 +27124,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -25301,6 +27212,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -25417,6 +27333,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -25530,6 +27451,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -25643,6 +27569,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -25756,11 +27687,16 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
     {
-        "formula": "RbHC2O.1H2O(aq)",
+        "formula": "RbH3(CO)2(aq)",
         "charge": 0,
         "molecular_weight": "144.51182 g/mol",
         "elements": [
@@ -25780,10 +27716,10 @@
             "@class": "Ion",
             "@version": null
         },
-        "formula_html": "RbHC<sub>2</sub>O<sub>.1</sub>H<sub>2</sub>O",
-        "formula_latex": "RbHC$_{2}$O$_{.1}$H$_{2}$O",
+        "formula_html": "RbH<sub>3</sub>(CO)<sub>2</sub>",
+        "formula_latex": "RbH$_{3}$(CO)$_{2}$",
         "formula_hill": "C2 H3 O2 Rb",
-        "formula_pretty": "RbHC2O.1H2O",
+        "formula_pretty": "RbH3(CO)2",
         "oxi_state_guesses": {
             "Rb": 1,
             "C": 0,
@@ -25851,6 +27787,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -25964,6 +27905,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -26056,6 +28002,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -26172,6 +28123,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -26288,6 +28244,136 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "RbOH(aq)",
+        "charge": 0,
+        "molecular_weight": "102.47514 g/mol",
+        "elements": [
+            "Rb",
+            "O",
+            "H"
+        ],
+        "chemsys": "H-O-Rb",
+        "pmg_ion": {
+            "Rb": 1,
+            "O": 1,
+            "H": 1,
+            "charge": 0,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "RbOH",
+        "formula_latex": "RbOH",
+        "formula_hill": "H O Rb",
+        "formula_pretty": "RbOH",
+        "oxi_state_guesses": {
+            "Rb": 1,
+            "O": -2,
+            "H": 1
+        },
+        "n_atoms": 3,
+        "n_elements": 3,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "3.03 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": {
+                "value": "9.05e-06 cm**2/s",
+                "reference": "CRC",
+                "data_type": "experimental"
+            }
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": {
+                    "value": "0.1404 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "0.2992 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "0.003028 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "6.0 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "molar_volume_pitzer": {
+                "Beta0": {
+                    "value": "0.001028 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta1": {
+                    "value": "-0.008523 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Beta2": {
+                    "value": "0.0 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Cphi": {
+                    "value": "-9.437e-05 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "V_o": {
+                    "value": "10.1 dimensionless",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                },
+                "Max_C": {
+                    "value": "5.981 mol/kg",
+                    "reference": "10.1021/je2009329",
+                    "data_type": "fitted"
+                }
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -26376,10 +28462,97 @@
                     "data_type": "fitted"
                 }
             },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            },
             "dielectric_zuber": {
                 "value": "2.08 dimensionless",
                 "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
                 "data_type": "fitted"
+            }
+        }
+    },
+    {
+        "formula": "ReO4[-1]",
+        "charge": -1,
+        "molecular_weight": "250.2046 g/mol",
+        "elements": [
+            "Re",
+            "O"
+        ],
+        "chemsys": "O-Re",
+        "pmg_ion": {
+            "Re": 1,
+            "O": 4,
+            "charge": -1,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "ReO<sub>4</sub><sup>-1</sup>",
+        "formula_latex": "ReO$_{4}$$^{-1}$",
+        "formula_hill": "O4 Re",
+        "formula_pretty": "ReO4^-1",
+        "oxi_state_guesses": {
+            "Re": 7,
+            "O": -2
+        },
+        "n_atoms": 5,
+        "n_elements": 2,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "2.16 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": {
+                "value": "1.462e-05 cm**2/s",
+                "reference": "CRC",
+                "data_type": "experimental"
+            }
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "Max_C": null
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": {
+                    "value": "-0.055 dm**3/mol",
+                    "reference": "https://doi.org/10.1021/cr00040a004",
+                    "data_type": "fitted"
+                }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -26462,83 +28635,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
-            }
-        }
-    },
-    {
-        "formula": "ReO4[-1]",
-        "charge": -1,
-        "molecular_weight": "250.2046 g/mol",
-        "elements": [
-            "Re",
-            "O"
-        ],
-        "chemsys": "O-Re",
-        "pmg_ion": {
-            "Re": 1,
-            "O": 4,
-            "charge": -1,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "ReO<sub>4</sub><sup>-1</sup>",
-        "formula_latex": "ReO$_{4}$$^{-1}$",
-        "formula_hill": "O4 Re",
-        "formula_pretty": "ReO4^-1",
-        "oxi_state_guesses": {
-            "Re": 7,
-            "O": -2
-        },
-        "n_atoms": 5,
-        "n_elements": 2,
-        "size": {
-            "radius_ionic": {
-                "value": "None",
-                "reference": "pymatgen",
-                "data_type": "experimental"
             },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "2.16 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null
-        },
-        "thermo": {
-            "ΔG_hydration": null,
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": {
-                "value": "1.462e-05 cm**2/s",
-                "reference": "CRC",
-                "data_type": "experimental"
-            }
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "Max_C": null
-            },
-            "molar_volume_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "V_o": null,
-                "Max_C": null
-            },
-            "viscosity_jones_dole": {
-                "B": {
-                    "value": "-0.055 dm**3/mol",
-                    "reference": "https://doi.org/10.1021/cr00040a004",
-                    "data_type": "fitted"
-                }
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -26609,6 +28710,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -26679,6 +28785,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -26749,6 +28860,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -26819,6 +28935,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -26889,6 +29010,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -26959,6 +29085,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -27032,6 +29163,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -27105,6 +29241,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -27178,6 +29319,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -27264,6 +29410,97 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "SO42[-1]",
+        "charge": -1,
+        "molecular_weight": "704.0398 g/mol",
+        "elements": [
+            "S",
+            "O"
+        ],
+        "chemsys": "O-S",
+        "pmg_ion": {
+            "S": 1,
+            "O": 42,
+            "charge": -1,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "SO<sub>42</sub><sup>-1</sup>",
+        "formula_latex": "SO$_{42}$$^{-1}$",
+        "formula_hill": "O42 S",
+        "formula_pretty": "SO42^-1",
+        "oxi_state_guesses": {
+            "S": 6,
+            "O": -0.16666666666666666
+        },
+        "n_atoms": 43,
+        "n_elements": 2,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "1.8 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": null
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "Max_C": null
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "2.08 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "13.4 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "34 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                }
             }
         }
     },
@@ -27337,6 +29574,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -27432,6 +29674,11 @@
                     "data_type": "fitted"
                 }
             },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            },
             "dielectric_zuber": {
                 "value": "-0.66 dimensionless",
                 "reference": "https://doi.org/10.1016/j.fluid.2014.05.037",
@@ -27506,76 +29753,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
-            }
-        }
-    },
-    {
-        "formula": "S[-2]",
-        "charge": -2,
-        "molecular_weight": "32.065 g/mol",
-        "elements": [
-            "S"
-        ],
-        "chemsys": "S",
-        "pmg_ion": {
-            "S": 1,
-            "charge": -2,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "S<sup>-2</sup>",
-        "formula_latex": "S$^{-2}$",
-        "formula_hill": "S",
-        "formula_pretty": "S^-2",
-        "oxi_state_guesses": {
-            "S": -2
-        },
-        "n_atoms": 1,
-        "n_elements": 1,
-        "size": {
-            "radius_ionic": {
-                "value": "1.7 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
             },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "1.8 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null
-        },
-        "thermo": {
-            "ΔG_hydration": {
-                "value": "-1576.0 ± 10 kJ/mol",
-                "reference": "10.1021/acs.jpca.9b05140",
-                "data_type": "experimental"
-            },
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": null
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "Max_C": null
-            },
-            "molar_volume_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "V_o": null,
-                "Max_C": null
-            },
-            "viscosity_jones_dole": {
-                "B": null
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -27652,6 +29834,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -27728,6 +29915,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -27817,6 +30009,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -27887,6 +30084,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -27966,6 +30168,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -28044,6 +30251,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -28117,6 +30329,101 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "SeO4[-1]",
+        "charge": -1,
+        "molecular_weight": "142.95759999999999 g/mol",
+        "elements": [
+            "Se",
+            "O"
+        ],
+        "chemsys": "O-Se",
+        "pmg_ion": {
+            "Se": 1,
+            "O": 4,
+            "charge": -1,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "SeO<sub>4</sub><sup>-1</sup>",
+        "formula_latex": "SeO$_{4}$$^{-1}$",
+        "formula_hill": "O4 Se",
+        "formula_pretty": "SeO4^-1",
+        "oxi_state_guesses": {
+            "Se": 4,
+            "O": -1.25
+        },
+        "n_atoms": 5,
+        "n_elements": 2,
+        "size": {
+            "radius_ionic": {
+                "value": "None",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": null,
+            "radius_vdw": {
+                "value": "1.9 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null
+        },
+        "thermo": {
+            "ΔG_hydration": null,
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": {
+                "value": "1.008e-05 cm**2/s",
+                "reference": "CRC",
+                "data_type": "experimental"
+            }
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "Max_C": null
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": {
+                    "value": "2.4 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "a2": {
+                    "value": "13.7 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                },
+                "d": {
+                    "value": "111 dimensionless",
+                    "reference": "https://doi.org/10.1016/j.cemconres.2017.08.030",
+                    "data_type": "fitted"
+                }
             }
         }
     },
@@ -28199,6 +30506,102 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
+            }
+        }
+    },
+    {
+        "formula": "SeO4[-2]",
+        "charge": -2,
+        "molecular_weight": "142.95759999999999 g/mol",
+        "elements": [
+            "Se",
+            "O"
+        ],
+        "chemsys": "O-Se",
+        "pmg_ion": {
+            "Se": 1,
+            "O": 4,
+            "charge": -2,
+            "@module": "pymatgen.core.ion",
+            "@class": "Ion",
+            "@version": null
+        },
+        "formula_html": "SeO<sub>4</sub><sup>-2</sup>",
+        "formula_latex": "SeO$_{4}$$^{-2}$",
+        "formula_hill": "O4 Se",
+        "formula_pretty": "SeO4^-2",
+        "oxi_state_guesses": {
+            "Se": 6,
+            "O": -2
+        },
+        "n_atoms": 5,
+        "n_elements": 2,
+        "size": {
+            "radius_ionic": {
+                "value": "1.84 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "radius_hydrated": {
+                "value": "3.84 Å",
+                "reference": "Nightingale1959",
+                "data_type": "experimental"
+            },
+            "radius_vdw": {
+                "value": "1.9 Å",
+                "reference": "pymatgen",
+                "data_type": "experimental"
+            },
+            "molar_volume": null,
+            "radius_ionic_marcus": {
+                "value": "2.43 ± 0.02 Å",
+                "reference": "Marcus2015",
+                "data_type": "experimental"
+            }
+        },
+        "thermo": {
+            "ΔG_hydration": {
+                "value": "-821.0 ± 6 kJ/mol",
+                "reference": "Marcus2015",
+                "data_type": "experimental"
+            },
+            "ΔG_formation": null
+        },
+        "transport": {
+            "diffusion_coefficient": {
+                "value": "nan cm**2/s",
+                "reference": "CRC",
+                "data_type": "experimental"
+            }
+        },
+        "model_parameters": {
+            "activity_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "Max_C": null
+            },
+            "molar_volume_pitzer": {
+                "Beta0": null,
+                "Beta1": null,
+                "Beta2": null,
+                "Cphi": null,
+                "V_o": null,
+                "Max_C": null
+            },
+            "viscosity_jones_dole": {
+                "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -28277,6 +30680,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -28390,6 +30798,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -28460,6 +30873,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -28543,6 +30961,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -28613,6 +31036,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -28688,6 +31116,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -28804,6 +31237,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -28920,6 +31358,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -29033,6 +31476,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -29146,6 +31594,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -29259,6 +31712,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -29346,6 +31804,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -29416,6 +31879,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -29495,6 +31963,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -29573,6 +32046,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -29643,6 +32121,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -29713,6 +32196,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -29805,102 +32293,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
-            }
-        }
-    },
-    {
-        "formula": "Th(NO3)4(aq)",
-        "charge": 0,
-        "molecular_weight": "480.05766 g/mol",
-        "elements": [
-            "Th",
-            "N",
-            "O"
-        ],
-        "chemsys": "N-O-Th",
-        "pmg_ion": {
-            "Th": 1,
-            "N": 4,
-            "O": 12,
-            "charge": 0,
-            "@module": "pymatgen.core.ion",
-            "@class": "Ion",
-            "@version": null
-        },
-        "formula_html": "Th(NO<sub>3</sub>)<sub>4</sub>",
-        "formula_latex": "Th(NO$_{3}$)$_{4}$",
-        "formula_hill": "N4 O12 Th",
-        "formula_pretty": "Th(NO3)4",
-        "oxi_state_guesses": {
-            "Th": 4,
-            "N": 5,
-            "O": -2
-        },
-        "n_atoms": 17,
-        "n_elements": 3,
-        "size": {
-            "radius_ionic": {
-                "value": "None",
-                "reference": "pymatgen",
-                "data_type": "experimental"
             },
-            "radius_hydrated": null,
-            "radius_vdw": {
-                "value": "2.45 Å",
-                "reference": "pymatgen",
-                "data_type": "experimental"
-            },
-            "molar_volume": null
-        },
-        "thermo": {
-            "ΔG_hydration": {
-                "value": "nan ± 6 kJ/mol",
-                "reference": "Marcus2015",
-                "data_type": "experimental"
-            },
-            "ΔG_formation": null
-        },
-        "transport": {
-            "diffusion_coefficient": null
-        },
-        "model_parameters": {
-            "activity_pitzer": {
-                "Beta0": {
-                    "value": "0.8219 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta1": {
-                    "value": "17.68 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Beta2": {
-                    "value": "0.0 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Cphi": {
-                    "value": "-0.1081 dimensionless",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                },
-                "Max_C": {
-                    "value": "1.4 mol/kg",
-                    "reference": "10.1021/je2009329",
-                    "data_type": "fitted"
-                }
-            },
-            "molar_volume_pitzer": {
-                "Beta0": null,
-                "Beta1": null,
-                "Beta2": null,
-                "Cphi": null,
-                "V_o": null,
-                "Max_C": null
-            },
-            "viscosity_jones_dole": {
-                "B": null
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -29980,6 +32377,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -30050,6 +32452,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -30120,6 +32527,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -30212,6 +32624,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -30304,6 +32721,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -30396,11 +32818,16 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
     {
-        "formula": "TlH(C3O)2.4H2O(aq)",
+        "formula": "TlH9(CO)6(aq)",
         "charge": 0,
         "molecular_weight": "381.51536 g/mol",
         "elements": [
@@ -30420,10 +32847,10 @@
             "@class": "Ion",
             "@version": null
         },
-        "formula_html": "TlH(C<sub>3</sub>O)<sub>2.4</sub>H<sub>2</sub>O",
-        "formula_latex": "TlH(C$_{3}$O)$_{2.4}$H$_{2}$O",
+        "formula_html": "TlH<sub>9</sub>(CO)<sub>6</sub>",
+        "formula_latex": "TlH$_{9}$(CO)$_{6}$",
         "formula_hill": "C6 H9 O6 Tl",
-        "formula_pretty": "TlH(C3O)2.4H2O",
+        "formula_pretty": "TlH9(CO)6",
         "oxi_state_guesses": {
             "Tl": 1,
             "C": 0.3333333333333333,
@@ -30491,6 +32918,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -30578,6 +33010,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -30653,6 +33090,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -30723,6 +33165,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -30810,6 +33257,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -30926,6 +33378,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31018,6 +33475,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31134,6 +33596,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31208,6 +33675,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31281,6 +33753,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31397,6 +33874,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31472,6 +33954,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31547,6 +34034,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31620,6 +34112,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31695,6 +34192,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31770,6 +34272,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31848,6 +34355,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31925,6 +34437,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -31995,6 +34512,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -32108,6 +34630,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -32224,6 +34751,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -32298,6 +34830,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -32373,6 +34910,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -32456,6 +34998,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -32572,6 +35119,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -32688,6 +35240,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -32801,6 +35358,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -32914,6 +35476,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -33027,6 +35594,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -33143,6 +35715,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -33234,6 +35811,11 @@
                     "reference": "https://doi.org/10.1021/cr00040a004",
                     "data_type": "fitted"
                 }
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     },
@@ -33309,6 +35891,11 @@
             },
             "viscosity_jones_dole": {
                 "B": null
+            },
+            "diffusion_temp_smolyakov": {
+                "a1": null,
+                "a2": null,
+                "d": null
             }
         }
     }

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -225,10 +225,8 @@ class NativeEOS(EOS):
         # search for Pitzer parameters
         param = solution.get_property(salt.formula, "model_parameters.activity_pitzer")
         if param is not None:
-            # TODO - consider re-enabling a log message recording what salt(s) are used as basis for activity
-            # calculation
-            # if verbose is True:
-            #     print("Calculating activity coefficient based on parent salt %s" % salt.formula)
+            # TODO - consider re-enabling a log message recording what salt(s) are used as basis for activity calculation
+            logger.info(f"Calculating activity coefficient based on parent salt {salt.formula}")
 
             # determine alpha1 and alpha2 based on the type of salt
             # see the May reference for the rules used to determine

--- a/src/pyEQL/solute.py
+++ b/src/pyEQL/solute.py
@@ -95,6 +95,7 @@ class Solute:
                 "Max_C": None,
             },
             "viscosity_jones_dole": {"B": None},
+            "diffusion_temp_smolyakov": {"a1": None, "a2": None, "d": None},
         }
     )
 

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -1789,9 +1789,9 @@ class Solution(MSONable):
         try:
             # get the molal-scale activity coefficient from the EOS engine
             molal = self.engine.get_activity_coefficient(solution=self, solute=solute)
-        except ValueError:
+        except (ValueError, ZeroDivisionError):
             logger.warning("Calculation unsuccessful. Returning unit activity coefficient.")
-            return ureg.Quantity("1 dimensionless")
+            return ureg.Quantity(1, "dimensionless")
 
         # if necessary, convert the activity coefficient to another scale, and return the result
         if scale == "molal":

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -115,6 +115,7 @@ class Solution(MSONable):
         # see https://rednafi.com/python/lru_cache_on_methods/
         self.get_property = lru_cache()(self._get_property)
         self.get_molar_conductivity = lru_cache()(self._get_molar_conductivity)
+        self.get_mobility = lru_cache()(self._get_mobility)
 
         # initialize the volume recalculation flag
         self.volume_update_required = False
@@ -350,6 +351,7 @@ class Solution(MSONable):
         # clear any cached solute properties that may depend on temperature
         self.get_property.cache_clear()
         self.get_molar_conductivity.cache_clear()
+        self.get_mobility.cache_clear()
 
     @property
     def pressure(self) -> Quantity:
@@ -2254,7 +2256,7 @@ class Solution(MSONable):
 
         return molar_cond.to("mS / cm / (mol/L)")
 
-    def get_mobility(self, solute: str) -> Quantity:
+    def _get_mobility(self, solute: str) -> Quantity:
         """
         Calculate the ionic mobility of the solute.
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -14,6 +14,7 @@ by USGS(PHREEQC)
 import numpy as np
 import pytest
 
+from pyEQL.activity_correction import _debye_parameter_activity, _debye_parameter_B
 from pyEQL.solution import Solution
 
 ## Tests of the pitzer model
@@ -50,6 +51,13 @@ def test_units_and_equality():
     a1 = s1.get_activity_coefficient("Na+")
     a2 = s1.get_activity_coefficient("Cl-")
     assert a1 == a2
+
+
+def test_debye_params():
+    # tests of the various Debye Huckel parameters
+    # A should be equal to 0.509 at 25 C, for log base 10
+    assert np.isclose(_debye_parameter_activity().magnitude / 2.303, 0.509, atol=1e-3)
+    assert np.isclose(_debye_parameter_B().to("nm**-1 * kg**0.5/mol**0.5").magnitude, 3.29, atol=1e-2)
 
 
 def test_activity_crc_HCl():

--- a/tests/test_phreeqc.py
+++ b/tests/test_phreeqc.py
@@ -123,11 +123,11 @@ def test_conductivity(s1, s2):
     assert np.isclose(s_kcl.conductivity.magnitude, 1.2824, atol=0.02)  # conductivity is in S/m
 
     # TODO - expected failures due to limited temp adjustment of diffusion coeff
-    # s_kcl.temperature = '5 degC'
-    # assert np.isclose(s_kcl.conductivity.magnitude, 0.81837, atol=0.02)
+    s_kcl.temperature = "5 degC"
+    assert np.isclose(s_kcl.conductivity.magnitude, 0.81837, atol=0.02)
 
-    # s_kcl.temperature = '50 degC'
-    # assert np.isclose(s_kcl.conductivity.magnitude, 1.91809, atol=0.02)
+    s_kcl.temperature = "50 degC"
+    assert np.isclose(s_kcl.conductivity.magnitude, 1.91809, atol=0.05)
 
     # TODO - conductivity model not very accurate at high conc.
     s_kcl = Solution({"K+": "1 mol/kg", "Cl-": "1 mol/kg"})

--- a/tests/test_solute_properties.py
+++ b/tests/test_solute_properties.py
@@ -14,6 +14,7 @@ in the testing are:
 """
 
 import numpy as np
+
 from pyEQL import Solution, ureg
 
 # relative tolerance between experimental and computed properties for this test file
@@ -83,7 +84,7 @@ class Test_molar_conductivity:
         result = s1.get_molar_conductivity("Mg+2").to("m**2*S/mol").magnitude
         expected = ureg.Quantity("106e-4 m**2 * S / mol").magnitude
 
-        assert np.isclose(result, expected, rtol=RTOL)
+        assert np.isclose(result, expected, atol=0.005)
 
     def test_molar_conductivity_chloride(self):
         # Cl- - 76.31 x 10 ** -4 m ** 2 S / mol
@@ -107,7 +108,7 @@ class Test_molar_conductivity:
         result = s1.get_molar_conductivity("SO4-2").to("m**2*S/mol").magnitude
         expected = ureg.Quantity("160.0e-4 m**2 * S / mol").magnitude
 
-        assert np.isclose(result, expected, rtol=RTOL)
+        assert np.isclose(result, expected, atol=0.002)
 
     def test_molar_conductivity_hydroxide(self):
         # OH- - 198 x 10 ** -4 m ** 2 S / mol

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -117,7 +117,12 @@ def test_diffusion_transport(s2):
     assert np.isclose(d25, 1.334e-9)
     assert np.isclose(s2.get_transport_number("Na+"), 0.396, atol=1e-3)
     assert np.isclose(s2.get_transport_number("Cl-"), 0.604, atol=1e-3)
+    # test setting a default value
+    assert s2.get_diffusion_coefficient("Cs+").magnitude == 0
+    assert s2.get_diffusion_coefficient("Cs+", default=1e-9).magnitude == 1e-9
     s2.temperature = "40 degC"
+    # TODO
+    # d40 = s2.get_diffusion_coefficient("Na+").magnitude
     d40 = s2.get_property("Na+", "transport.diffusion_coefficient").magnitude
     assert np.isclose(d40, d25 * 40 / 25)
 

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -116,36 +116,49 @@ def test_diffusion_transport(s1, s2):
     # test ionic strength adjustment
     assert s1.get_diffusion_coefficient("H+") > s2.get_diffusion_coefficient("H+")
 
-    # for Na+, d=122, a1=1.52, a2=3.7, A=1.173802 at 25 DegC, B = 3.2843078+10
+    # for Na+, d=122, a1=1.52, a2=3.7, A=1.173802/2.303 at 25 DegC, B = 3.2843078+10
     factor = np.exp(
         -1.52
         * 1.173802
+        / 2.303
         * 1
         * np.sqrt(s2.ionic_strength.magnitude)
-        / (1 + 3.2843078 + 10 * np.sqrt(s2.ionic_strength.magnitude) * 3.7 / (1 + s2.ionic_strength.magnitude**0.75))
+        / (1 + 3.2843078e10 * np.sqrt(s2.ionic_strength.magnitude) * 3.7 / (1 + s2.ionic_strength.magnitude**0.75))
     )
     assert np.isclose(
-        factor * s2.get_diffusion_coefficient("Na+", activity_correction=False).magnitude,
+        factor * s2.get_diffusion_coefficient("Na+").magnitude,
         s2.get_diffusion_coefficient("Na+").magnitude,
         atol=5e-11,
     )
+    s_dilute = Solution({"Na+": "1 mmol/L", "Cl-": "1 mmol/L"})
+    assert np.isclose(
+        s_dilute.get_diffusion_coefficient("Na+", activity_correction=False).magnitude, 1.334e-9, atol=1e-12
+    )
+    assert np.isclose(s_dilute.get_transport_number("Na+"), 0.396, atol=1e-3)
+    assert np.isclose(s_dilute.get_transport_number("Cl-"), 0.604, atol=1e-3)
 
-    d25 = s2.get_diffusion_coefficient("Na+", activity_correction=False).magnitude
-    assert np.isclose(d25, 1.334e-9, atol=1e-11)
-    assert np.isclose(s2.get_transport_number("Na+"), 0.396, atol=1e-3)
-    assert np.isclose(s2.get_transport_number("Cl-"), 0.604, atol=1e-3)
     # test setting a default value
     assert s2.get_diffusion_coefficient("Cs+").magnitude == 0
     assert s2.get_diffusion_coefficient("Cs+", default=1e-9).magnitude == 1e-9
+    d25 = s2.get_diffusion_coefficient("Na+", activity_correction=False).magnitude
+    nu25 = s2.water_substance.nu
     s2.temperature = "40 degC"
-    d40 = s2.get_diffusion_coefficient("Na+").magnitude
+    d40 = s2.get_diffusion_coefficient("Na+", activity_correction=False).magnitude
+    nu40 = s2.water_substance.nu
     assert np.isclose(
         d40,
-        d25
-        * np.exp(122 / (273.15 + 40) - 122 / 298.15)
-        * (0.0008898985817971047 / s2.viscosity_dynamic.to("Pa*s").magnitude),
+        d25 * np.exp(122 / (273.15 + 40) - 122 / 298.15) * (nu25 / nu40),
         atol=5e-11,
     )
+
+    # test correction factors for concentration, as per Appelo 2017 Fig 5
+    D1 = Solution({"Na+": "1 umol/L", "Cl-": "1 umol/L"}).get_diffusion_coefficient("Na+").magnitude
+    D2 = Solution({"Na+": "1.7 mol/kg", "Cl-": "1.7 mol/kg"}).get_diffusion_coefficient("Na+").magnitude
+    assert np.isclose(D2 / D1, 0.54, atol=1e-2)
+
+    D1 = Solution({"K+": "1 umol/L", "Cl-": "1 umol/L"}).get_diffusion_coefficient("K+").magnitude
+    D2 = Solution({"K+": "0.5 mol/kg", "Cl-": "0.5 mol/kg"}).get_diffusion_coefficient("K+").magnitude
+    assert np.isclose(D2 / D1, 0.80, atol=1e-2)
 
 
 def test_init_raises():
@@ -443,24 +456,48 @@ def test_tds(s1, s2, s5):
 
 
 def test_conductivity(s1, s2):
-    # even an empty solution should have some conductivity
-    assert s1.conductivity > 0
-    s_nacl = Solution({"Na+": "2298 mg/L", "Cl-": "3544 ppm"})
-    assert np.isclose(s_nacl.conductivity.to("mS/cm").magnitude, 10, atol=1)  # conductivity ~ 10 mS/cm
-    # per CRC handbook "standard Kcl solutions for calibratinG conductiVity cells", 0.1m KCl has a conductivity of 12.824 mS/cm at 25 C
+    # per CRC handbook - "electrical conductiVity of Water" , conductivity of pure water
+    # at 25 and 100 C is 0.0550 and 0.765 uS/cm
+    assert np.isclose(s1.conductivity.to("uS/cm").magnitude, 0.055, atol=1e-3)
+
+    # TODO - seems to be a possible bug related to setting temperature here
+    # s1.temperature = "100 degC"
+    # s2 = Solution(temperature='100 degC')
+    # assert np.isclose(s1.conductivity.to('uS/cm').magnitude, 0.765, atol=1e-3)
+
+    # CRC handbook table - "equivalent conductivity of electrolytes in aqueous solution"
+    # nacl
+    for conc, cond in zip([0.001, 0.05, 0.1], [123.68, 111.01, 106.69]):
+        s1 = Solution({"Na+": f"{conc} mol/L", "Cl-": f"{conc} mol/L"})
+        assert np.isclose(
+            s1.conductivity.to("S/m").magnitude, conc * cond / 10, atol=0.5
+        ), f"Conductivity test failed for NaCl at {conc} mol/L. Result = {s1.conductivity.to('S/m').magnitude}"
+
+    # higher concentration data points from Appelo, 2017 Figure 4.
+    s1 = Solution({"Na+": "2 mol/kg", "Cl-": "2 mol/kg"})
+    assert np.isclose(s1.conductivity.to("mS/cm").magnitude, 145, atol=10)
+
+    # MgCl2
+    for conc, cond in zip([0.001, 0.05, 0.1], [124.15, 114.49, 97.05]):
+        s1 = Solution({"Mg+2": f"{conc} mol/L", "Cl-": f"{2*conc} mol/L"})
+        assert np.isclose(
+            s1.conductivity.to("S/m").magnitude, 2 * conc * cond / 10, atol=1
+        ), f"Conductivity test failed for MgCl2 at {conc} mol/L. Result = {s1.conductivity.to('S/m').magnitude}"
+
+    # per CRC handbook "standard KCl solutions for calibrating conductivity cells", 0.1m KCl has a conductivity of 12.824 mS/cm at 25 C
     s_kcl = Solution({"K+": "0.1 mol/kg", "Cl-": "0.1 mol/kg"})
-    assert np.isclose(s_kcl.conductivity.magnitude, 1.2824, atol=0.02)  # conductivity is in S/m
+    assert np.isclose(s_kcl.conductivity.magnitude, 1.2824, atol=0.25)  # conductivity is in S/m
 
     # TODO - expected failures due to limited temp adjustment of diffusion coeff
     s_kcl.temperature = "5 degC"
-    assert np.isclose(s_kcl.conductivity.magnitude, 0.81837, atol=0.02)
+    assert np.isclose(s_kcl.conductivity.magnitude, 0.81837, atol=0.2)
 
     s_kcl.temperature = "50 degC"
-    assert np.isclose(s_kcl.conductivity.magnitude, 1.91809, atol=0.05)
+    assert np.isclose(s_kcl.conductivity.magnitude, 1.91809, atol=0.2)
 
     # TODO - conductivity model not very accurate at high conc.
     s_kcl = Solution({"K+": "1 mol/kg", "Cl-": "1 mol/kg"})
-    assert np.isclose(s_kcl.conductivity.magnitude, 10.862, rtol=0.2)
+    assert np.isclose(s_kcl.conductivity.magnitude, 10.862, atol=0.45)
 
 
 def test_arithmetic_and_copy(s2, s6):


### PR DESCRIPTION
## Summary

- `Solution`: Revamped docstrings for `conductivity`, `get_transport_number`, `get_molar_conductivity`, and
  `get_diffusion_coefficient`.
- `Solution`: new method `get_diffusion_coefficient` for dedicated retrieval of diffusion coefficients. This method
  implements an improved algorithm for temperature adjustment and a new algorithm for adjusting infinite dilution D values
  for ionic strengthe effects. The algorithm is identical to that implemented in PHREEQC >= 3.4.
- Database: empirical parameters for temperature and ionic strength adjustment of diffusion coefficients for 15 solutes
- Added tests for temperature and ionic strength adjustment and conductivity

Closes #56 
