### PR TITLE
Use IAPWS97 for speed; cache instance via utility function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `Solution.water_substance` - use the IAPWS97 model instead of IAPWS95 whenever possible, for a substantial speedup.
+
 ## [0.10.0] - 2023-11-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Solution.water_substance` - use the IAPWS97 model instead of IAPWS95 whenever possible, for a substantial speedup.
 
+### Added
+
+- utility function `create_water_substance` with caching to speed up access to IAPWS instances
+
 ## [0.10.0] - 2023-11-12
 
 ### Added

--- a/src/pyEQL/activity_correction.py
+++ b/src/pyEQL/activity_correction.py
@@ -14,11 +14,11 @@ are called from within the get_activity_coefficient method of the Solution class
 """
 import math
 
-from iapws import IAPWS95
 from pint import Quantity
 
 from pyEQL import ureg
 from pyEQL.logging_system import logger
+from pyEQL.utils import create_water_substance
 
 
 def _debye_parameter_B(temperature: str = "25 degC") -> Quantity:
@@ -49,9 +49,9 @@ def _debye_parameter_B(temperature: str = "25 degC") -> Quantity:
 
         https://en.wikipedia.org/wiki/Debye%E2%80%93H%C3%BCckel_equation
     """
-    water_substance = IAPWS95(
-        T=ureg.Quantity(temperature).to("K").magnitude,
-        P=ureg.Quantity("1 atm").to("MPa").magnitude,
+    water_substance = create_water_substance(
+        ureg.Quantity(temperature),
+        ureg.Quantity("1 atm"),
     )
 
     param_B = (
@@ -99,9 +99,9 @@ def _debye_parameter_activity(temperature: str = "25 degC") -> "Quantity":
         :py:func:`_debye_parameter_osmotic`
 
     """
-    water_substance = IAPWS95(
-        T=ureg.Quantity(temperature).to("K").magnitude,
-        P=ureg.Quantity("1 atm").to("MPa").magnitude,
+    water_substance = create_water_substance(
+        ureg.Quantity(temperature),
+        ureg.Quantity("1 atm"),
     )
 
     debyeparam = (
@@ -202,9 +202,9 @@ def _debye_parameter_volume(temperature="25 degC"):
     _debye_parameter_osmotic
 
     """
-    water_substance = IAPWS95(
-        T=ureg.Quantity(temperature).magnitude,
-        P=ureg.Quantity("1 atm").to("MPa").magnitude,
+    water_substance = create_water_substance(
+        ureg.Quantity(temperature),
+        ureg.Quantity("1 atm"),
     )
 
     # TODO - add partial derivatives to calculation

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -9,7 +9,10 @@ pyEQL utilities
 from collections import UserDict
 from functools import lru_cache
 
+from iapws import IAPWS95, IAPWS97
 from pymatgen.core.ion import Ion
+
+from pyEQL import ureg
 
 
 @lru_cache
@@ -54,6 +57,29 @@ def format_solutes_dict(solute_dict: dict, units: str):
         raise TypeError("solute_dict must be a dictionary. Refer to the doc for proper formatting.")
 
     return {key: f"{value!s} {units}" for key, value in solute_dict.items()}
+
+
+@lru_cache
+@ureg.wraps(ret=None, args=["K", "MPa"])
+def create_water_substance(temperature: float, pressure: float):
+    """
+    Instantiate a water substance model from IAPWS
+
+    Args:
+        temperature: the desired temperature in K
+        pressure: the desired pressure in MPa
+
+    Notes:
+        The IAPWS97 model is much faster than IAPWS95, but the latter can do temp
+        below zero. See https://github.com/jjgomera/iapws/issues/14. Hence,
+        IAPWS97 will be used except when `temperature` is less than 0 degC.
+
+    Returns:
+        A IAPWS97 or IAPWS95 instance
+    """
+    if temperature >= 273.15:
+        return IAPWS97(T=temperature, P=pressure)
+    return IAPWS95(T=temperature, P=pressure)
 
 
 class FormulaDict(UserDict):

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -60,7 +60,7 @@ def format_solutes_dict(solute_dict: dict, units: str):
 
 
 @lru_cache
-@ureg.wraps(ret=None, args=["K", "MPa"])
+@ureg.wraps(ret=None, args=["K", "MPa"], strict=False)
 def create_water_substance(temperature: float, pressure: float):
     """
     Instantiate a water substance model from IAPWS

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,11 @@
 Tests of pyEQL.utils module
 
 """
+from iapws import IAPWS95, IAPWS97
 from pytest import raises
 
-from pyEQL.utils import FormulaDict, format_solutes_dict, standardize_formula
+from pyEQL import ureg
+from pyEQL.utils import FormulaDict, create_water_substance, format_solutes_dict, standardize_formula
 
 
 def test_standardize_formula():
@@ -50,3 +52,8 @@ def test_format_solute():
     error_msg = "solute_dict must be a dictionary. Refer to the doc for proper formatting."
     with raises(TypeError, match=error_msg):
         format_solutes_dict(bad_test, units="mol/kg")
+
+
+def test_create_water_substance():
+    assert isinstance(create_water_substance(300, 0.1), IAPWS97)
+    assert isinstance(create_water_substance(ureg.Quantity(-15, "degC"), 0.1), IAPWS95)


### PR DESCRIPTION
## Summary

Use `IAPWS97` water model instead of `IAPWS95` when possible, because the former instantiates much more quickly. Also create a utility function `create_water_substance` with caching to speed up access to these instances.
