### PR TITLE
equilibrate(): fix charge balancing bugs in Native and PhreeqC engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `phreeqpython` solution object in between calls, only re-initializing it if the composition
   of the `Solution` has changed since the previous call.
 
+  ### Fixed
+
+  - `equilibrate`: Fixed several bugs affecting `NativeEOS` and `PhreeqcEOS` in which calling `equilibrate()`
+    would mess up the charge balance. This was especially an issue if `balance_charge` was set to something
+    other than `pH`.
+
   ### Removed
 
   - `equilibrium.equilibrate_phreeqc()` has been removed to reduce redundant code. All its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `phreeqpython` solution object in between calls, only re-initializing it if the composition
   of the `Solution` has changed since the previous call.
 
-  ### Fixed
+### Fixed
 
-  - `equilibrate`: Fixed several bugs affecting `NativeEOS` and `PhreeqcEOS` in which calling `equilibrate()`
-    would mess up the charge balance. This was especially an issue if `balance_charge` was set to something
-    other than `pH`.
+- `equilibrate`: Fixed several bugs affecting `NativeEOS` and `PhreeqcEOS` in which calling `equilibrate()`
+  would mess up the charge balance. This was especially an issue if `balance_charge` was set to something
+  other than `pH`.
 
-  ### Removed
+### Removed
 
-  - `equilibrium.equilibrate_phreeqc()` has been removed to reduce redundant code. All its
-    was absorbed into `NativeEOS` and `PhreeqcEOS`
+- `equilibrium.equilibrate_phreeqc()` has been removed to reduce redundant code. All its
+  was absorbed into `NativeEOS` and `PhreeqcEOS`
 
 ## [0.10.1] - 2023-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.0] - 2023-11-20
 
 ### Changed
 
-- `PhreeqcEOS`: performance improvements for the `phreeqc` engine. The `EOS` instance now retains
-  the `phreeqpython` solution object in between calls, only re-initializing it if the composition
-  of the `Solution` has changed since the previous call.
 - `PhreeqcEOS`: performance improvements for the `phreeqc` engine. The `EOS` instance now retains
   the `phreeqpython` solution object in between calls, only re-initializing it if the composition
   of the `Solution` has changed since the previous call.

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -187,12 +187,10 @@ class NativeEOS(EOS):
             "water": solv_mass,
             "density": solution.density.to("g/mL").magnitude,
         }
-        balance_charge = solution.balance_charge
-        if balance_charge == "pH":
+        if solution.balance_charge == "pH":
             d["pH"] = str(d["pH"]) + " charge"
-        if balance_charge == "pE":
+        if solution.balance_charge == "pE":
             d["pe"] = str(d["pe"]) + " charge"
-        solution.components.copy()
 
         # add the composition to the dict
         # also, skip H and O
@@ -209,7 +207,7 @@ class NativeEOS(EOS):
                 key = bare_el
 
             # tell PHREEQC which species to use for charge balance
-            if el == balance_charge:
+            if solution.balance_charge is not None and el in solution.balance_charge:
                 key += " charge"
             d[key] = mol / solv_mass
 

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -1077,7 +1077,7 @@ class Solution(MSONable):
         Return a list of all species associated with a given element. Elements (keys) are
         suffixed with their oxidation state in parentheses, e.g.,
 
-        {"Na(1)":["Na[+1]", "NaOH(aq)"]}
+        {"Na(1.0)":["Na[+1]", "NaOH(aq)"]}
 
         Species associated with each element are sorted in descending order of the amount
         present (i.e., the first species listed is the most abundant).
@@ -1109,7 +1109,7 @@ class Solution(MSONable):
         Return a dict of Element: amount in mol
 
         Elements (keys) are suffixed with their oxidation state in parentheses,
-        e.g. "Fe(2)", "Cl(-1)".
+        e.g. "Fe(2.0)", "Cl(-1.0)".
         """
         d = {}
         for s, mol in self.components.items():
@@ -1140,7 +1140,7 @@ class Solution(MSONable):
 
         Args:
             element: The symbol of the element of interest. The symbol can optionally be followed by the
-                oxidation state in parentheses, e.g., "Na(1)", "Fe(2)", or "O(0)". If no oxidation state
+                oxidation state in parentheses, e.g., "Na(1.0)", "Fe(2.0)", or "O(0.0)". If no oxidation state
                 is given, the total concentration of the element (over all oxidation states) is returned.
         units : str
                     Units desired for the output. Examples of valid units are

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -91,7 +91,7 @@ class Solution(MSONable):
                 'pH', which will adjust the solution pH to balance charge, 'pE' which will adjust the
                 redox equilibrium to balance charge, or the name of a dissolved species e.g. 'Ca+2' or 'Cl-' that will be
                 added/subtracted to balance charge. If set to None, no charge balancing will be performed either on init
-                or when equilibrate() is called.
+                or when equilibrate() is called. Note that in this case, equilibrate() can distort the charge balance!
             solvent: Formula of the solvent. Solvents other than water are not supported at
                 this time.
             engine: Electrolyte modeling engine to use. See documentation for details on the available engines.

--- a/tests/test_phreeqc.py
+++ b/tests/test_phreeqc.py
@@ -160,7 +160,7 @@ def test_conductivity(s1):
     assert np.isclose(s_kcl.conductivity.magnitude, 10.862, rtol=0.05)
 
 
-def test_equilibrate(s1, s2, s5_pH, caplog):
+def test_equilibrate(s1, s2, s5_pH, s6_Ca, caplog):
     assert "H2(aq)" not in s1.components
     orig_pH = s1.pH
     orig_pE = s1.pE
@@ -224,3 +224,12 @@ def test_equilibrate(s1, s2, s5_pH, caplog):
     assert "HCO3[-1]" in s5_pH.components
     assert s5_pH.pH > orig_pH
     assert np.isclose(s5_pH.pE, orig_pE)
+
+    # test equilibrate() with a non-pH balancing species
+    assert np.isclose(s6_Ca.charge_balance, 0, atol=1e-8)
+    initial_Ca = s6_Ca.get_total_amount("Ca", "mol").magnitude
+    assert s6_Ca.balance_charge == "Ca[+2]"
+    s6_Ca.equilibrate()
+    print(s6_Ca.components)
+    assert s6_Ca.get_total_amount("Ca", "mol").magnitude != initial_Ca
+    assert np.isclose(s6_Ca.charge_balance, 0, atol=1e-8)

--- a/tests/test_phreeqc.py
+++ b/tests/test_phreeqc.py
@@ -230,6 +230,5 @@ def test_equilibrate(s1, s2, s5_pH, s6_Ca, caplog):
     initial_Ca = s6_Ca.get_total_amount("Ca", "mol").magnitude
     assert s6_Ca.balance_charge == "Ca[+2]"
     s6_Ca.equilibrate()
-    print(s6_Ca.components)
     assert s6_Ca.get_total_amount("Ca", "mol").magnitude != initial_Ca
     assert np.isclose(s6_Ca.charge_balance, 0, atol=1e-8)


### PR DESCRIPTION
Sometimes, `equilibrate` would mess up the charge balance even when a solution was initially electroneutral. This was especially true when `balance_charge` was equal to something other than `pH`