### PR TITLE
Revert change to __add__

### DIFF
--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -2513,7 +2513,7 @@ class Solution(MSONable):
         mix_pE = -math.log10((mol_e_self + mol_e_other) / mix_vol.to("L").magnitude)
 
         # create a new solution
-        return self.__class__(
+        return Solution(
             mix_species.data,  # pass a regular dict instead of the FormulaDict
             volume=str(mix_vol),
             pressure=str(mix_pressure),


### PR DESCRIPTION
Reverts change to `Solution.__add__` in #92 . Any class that inherits from `Solution` is not guaranteed to have the same call signature in `__init__`, so such classes will probably need to re-implement `__add__` anyway. Explicitly invoking the classname `Solution` rather than impliciltly (`self.__class__`) seems to be more consistent with how magic methods are usually implemented.