### PR TITLE
Solution.get_total_amount: bufix for mass based units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `Solution.get_total_amount`: Bugfix that would cause the method to fail if
+  mass-based units such as mg/L or ppm were requested.
+
 ## [0.12.0] - 2024-02-15
 
 ### Added
@@ -19,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Solution.__add_`: Bugfix in the addition operation `+` that could cause problems with
+- `Solution.__add__`: Bugfix in the addition operation `+` that could cause problems with
   child classes (i.e., classes that inherit from `Solution`) to work improperly
 
 ### Changed

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -1204,7 +1204,7 @@ class Solution(MSONable):
                     "[mass]/[length]**3",
                     "[mass]/[mass]",
                 ):
-                    TOT += amt * ion.to_weight_dict["el"]  # returns {el: wt fraction}
+                    TOT += amt * ion.to_weight_dict[el]  # returns {el: wt fraction}
 
         return TOT
 

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -392,7 +392,7 @@ def test_components_by_element(s1, s2):
 
 
 def test_get_total_amount(s2):
-    assert np.isclose(s2.get_total_amount("Na(1)", "mol").magnitude, 8)
+    assert np.isclose(s2.get_total_amount("Na(1)", "g").magnitude, 8 * 58, 44)
     assert np.isclose(s2.get_total_amount("Na", "mol").magnitude, 8)
     sox = Solution({"Fe+2": "10 mM", "Fe+3": "40 mM", "Cl-": "50 mM"}, pH=3)
     assert np.isclose(sox.get_total_amount("Fe(2)", "mol/L").magnitude, 0.01)


### PR DESCRIPTION
Fixes a bug in which, due to a stray set of quotation marks, `get_total_amount` would fail with mass-based units:

```
   1200             TOT += amt * ion.get_el_amt_dict()[el]  # returns {el: mol per formula unit}
   1202         elif ureg.Quantity(units).dimensionality in (
   1203             "[mass]",
   1204             "[mass]/[length]**3",
   1205             "[mass]/[mass]",
   1206         ):
-> 1207             TOT += amt * ion.to_weight_dict["el"]  # returns {el: wt fraction}
   1209 return TOT

KeyError: 'el'
```