### PR TITLE
Solution.get_total_amount: bugfix for aliased units like ppm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.2] - 2024-02-25
+
+### Fixed
+
+- `Solution.get_total_amount`: Bugfix that would cause the method to fail if
+  units with names not natively understood by `pint` (e.g., 'ppm') were passed.
+
 ## [0.12.1] - 2024-02-25
 
 ### Fixed

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -1165,7 +1165,7 @@ class Solution(MSONable):
         --------
         get_amount
         """
-        TOT: Quantity = ureg.Quantity(f"0 {units}")
+        TOT: Quantity = 0
 
         # standardize the element formula
         el = str(Element(element.split("(")[0]))

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -394,6 +394,7 @@ def test_components_by_element(s1, s2):
 def test_get_total_amount(s2):
     assert np.isclose(s2.get_total_amount("Na(1)", "g").magnitude, 8 * 58, 44)
     assert np.isclose(s2.get_total_amount("Na", "mol").magnitude, 8)
+    assert np.isclose(s2.get_total_amount("Na", "ppm").magnitude, 4 * 23300, rtol=0.02)
     sox = Solution({"Fe+2": "10 mM", "Fe+3": "40 mM", "Cl-": "50 mM"}, pH=3)
     assert np.isclose(sox.get_total_amount("Fe(2)", "mol/L").magnitude, 0.01)
     assert np.isclose(sox.get_total_amount("Fe(3)", "mol/L").magnitude, 0.04)


### PR DESCRIPTION
Bugfix that would cause the method to fail if units with names not natively understood by `pint` (e.g., 'ppm') were passed.