### PR TITLE
alpha: fix incorrect calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.13.0] - 2024-3-05
+
 ### Fixed
 
 - `equilibrium.alpha()`: Fixed incorrect calculation of acid-base distribution coefficient for multiprotic acids.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `equilibrium.alpha()`: Fixed incorrect calculation of acid-base distribution coefficient for multiprotic acids.
 - Docs: fixed many small problems in documentation causing equations and examples to
   render incorrectly.
 - `Solution.from_file`: Add missing `@classmethod` decorator; update documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.13.0] - 2024-3-05
+## [0.13.0] - 2024-03-05
 
 ### Fixed
 

--- a/tests/test_equilibrium.py
+++ b/tests/test_equilibrium.py
@@ -1,0 +1,42 @@
+"""
+Tests of pyEQL.equilibrium module
+
+"""
+import numpy as np
+
+from pyEQL.equilibrium import alpha
+
+
+def test_alpha():
+    # for each case, test pH << pKa, pH=pKa, pH >> pKa
+
+    # monoprotic acid
+    assert np.isclose(alpha(0, 3, [7]), 1, atol=1e-3)
+    assert np.isclose(alpha(1, 3, [7]), 0, atol=1e-3)
+
+    assert np.isclose(alpha(0, 7, [7]), 0.5, atol=1e-3)
+    assert np.isclose(alpha(1, 7, [7]), 0.5, atol=1e-3)
+
+    assert np.isclose(alpha(0, 10, [7]), 0, atol=1e-3)
+    assert np.isclose(alpha(1, 10, [7]), 1, atol=1e-3)
+
+    # carbonic acid, diprotic
+    assert np.isclose(alpha(0, 3, [6.35, 10.33]), 1, atol=1e-3)
+    assert np.isclose(alpha(1, 3, [6.35, 10.33]), 0, atol=1e-3)
+    assert np.isclose(alpha(2, 3, [6.35, 10.33]), 0, atol=1e-3)
+
+    assert np.isclose(alpha(0, 6.35, [6.35, 10.33]), 0.5, atol=1e-3)
+    assert np.isclose(alpha(1, 6.35, [6.35, 10.33]), 0.5, atol=1e-3)
+
+    assert np.isclose(alpha(0, 7.35, [6.35, 10.33]), 0.1, atol=1e-2)
+    # test sorting
+    assert np.isclose(alpha(0, 7.35, [10.33, 6.35]), 0.1, atol=1e-2)
+    assert np.isclose(alpha(1, 7.35, [6.35, 10.33]), 0.9, atol=1e-2)
+    assert np.isclose(alpha(2, 7.35, [6.35, 10.33]), 0, atol=1e-3)
+
+    assert np.isclose(alpha(1, 10.33, [6.35, 10.33]), 0.5, atol=1e-3)
+    assert np.isclose(alpha(2, 10.33, [6.35, 10.33]), 0.5, atol=1e-3)
+
+    assert np.isclose(alpha(0, 12.33, [6.35, 10.33]), 0, atol=1e-3)
+    assert np.isclose(alpha(1, 12.33, [6.35, 10.33]), 0.01, atol=1e-2)
+    assert np.isclose(alpha(2, 12.33, [6.35, 10.33]), 0.99, atol=1e-2)


### PR DESCRIPTION
Fixes incorrect calculation results from `equilibrium.alpha`. Note that this utility function is currently provided only as a convenience; it is not utilized anywhere within `pyEQL` at present.