### PR TITLE
Fix charge balancing error and dependency housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replace `math` with `numpy` functions throughout. This mainly changed calls to `log` and `exp`.
 - Docs: Fix missing close parentheses in docstring (@Andrew S. Rosen)
 
 ## [1.0.0] - 2024-03-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `NPY201` ruleset to `ruff` configuration to check support for `numpy` 2.0
+
 ### Fixed
 
 - `UnicodeDecodeError` when trying to connect to ion database on non-English platforms ([#122](https://github.com/KingsburyLab/pyEQL/issues/122))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.0.1] - 2024-06-17
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `NativeEOS` and `PHREEQCEOS` `equilibrate`: Fixed a charge balancing bug that cause repeated calls to `equlibrate` to
+  severely distort the pH and/or the composition. (#141)[https://github.com/KingsburyLab/pyEQL/issues/141]
 - `UnicodeDecodeError` when trying to connect to ion database on non-English platforms ([#122](https://github.com/KingsburyLab/pyEQL/issues/122))
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ select = [
   "UP",   # pyupgrade
   "W",    # pycodestyle warning
   "YTT",  # flake8-2020
+  "NPY201", # Numpy 2.0 migration
 ]
 ignore = [
   "B008",    # Do not perform function call `unit` in argument defaults

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ python_requires = >=3.9
 # For more information, check out https://semver.org/.
 install_requires =
     pint>=0.19
-    numpy
+    numpy<2
     scipy
     pymatgen==2024.5.1
     iapws

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     pint>=0.19
     numpy
     scipy
-    pymatgen>=2023.10.11
+    pymatgen==2024.5.1
     iapws
     monty
     maggma>=0.67.0

--- a/src/pyEQL/activity_correction.py
+++ b/src/pyEQL/activity_correction.py
@@ -14,8 +14,8 @@ are called from within the get_activity_coefficient method of the Solution class
 """
 
 import logging
-import math
 
+import numpy as np
 from pint import Quantity
 
 from pyEQL import ureg
@@ -114,8 +114,8 @@ def _debye_parameter_activity(temperature: str = "25 degC") -> "Quantity":
 
     debyeparam = (
         ureg.elementary_charge**3
-        * (2 * math.pi * ureg.N_A * ureg.Quantity(water_substance.rho, "g/L")) ** 0.5
-        / (4 * math.pi * ureg.epsilon_0 * water_substance.epsilon * ureg.boltzmann_constant * T) ** 1.5
+        * (2 * np.pi * ureg.N_A * ureg.Quantity(water_substance.rho, "g/L")) ** 0.5
+        / (4 * np.pi * ureg.epsilon_0 * water_substance.epsilon * ureg.boltzmann_constant * T) ** 1.5
     )
 
     logger.debug(rf"Computed Debye-Huckel Limiting Law Constant A^{{\gamma}} = {debyeparam} at {temperature}")
@@ -248,7 +248,7 @@ def get_activity_coefficient_debyehuckel(ionic_strength, z=1, temperature="25 de
 
     log_f = -_debye_parameter_activity(temperature) * z**2 * ionic_strength**0.5
 
-    return math.exp(log_f) * ureg.Quantity(1, "dimensionless")
+    return np.exp(log_f) * ureg.Quantity(1, "dimensionless")
 
 
 def get_activity_coefficient_guntelberg(ionic_strength, z=1, temperature="25 degC"):
@@ -285,7 +285,7 @@ def get_activity_coefficient_guntelberg(ionic_strength, z=1, temperature="25 deg
 
     log_f = -_debye_parameter_activity(temperature) * z**2 * ionic_strength**0.5 / (1 + ionic_strength.magnitude**0.5)
 
-    return math.exp(log_f) * ureg.Quantity(1, "dimensionless")
+    return np.exp(log_f) * ureg.Quantity(1, "dimensionless")
 
 
 def get_activity_coefficient_davies(ionic_strength, z=1, temperature="25 degC"):
@@ -327,7 +327,7 @@ def get_activity_coefficient_davies(ionic_strength, z=1, temperature="25 degC"):
         * (ionic_strength.magnitude**0.5 / (1 + ionic_strength.magnitude**0.5) - 0.2 * ionic_strength.magnitude)
     )
 
-    return math.exp(log_f) * ureg.Quantity(1, "dimensionless")
+    return np.exp(log_f) * ureg.Quantity(1, "dimensionless")
 
 
 def get_activity_coefficient_pitzer(
@@ -437,7 +437,7 @@ def get_activity_coefficient_pitzer(
         b,
     )
 
-    return math.exp(loggamma) * ureg.Quantity(1, "dimensionless")
+    return np.exp(loggamma) * ureg.Quantity(1, "dimensionless")
 
 
 def get_apparent_volume_pitzer(
@@ -533,7 +533,7 @@ def get_apparent_volume_pitzer(
         (nu_cation + nu_anion)
         * abs(z_cation * z_anion)
         * (_debye_parameter_volume(temperature) / 2 / b)
-        * math.log(1 + b * ionic_strength**0.5)
+        * np.log(1 + b * ionic_strength**0.5)
     )
 
     third_term = (
@@ -566,7 +566,7 @@ def _pitzer_f1(x):
     # return 0 if the input is 0
     if x == 0:
         return 0
-    return 2 * (1 - (1 + x) * math.exp(-x)) / x**2
+    return 2 * (1 - (1 + x) * np.exp(-x)) / x**2
 
 
 def _pitzer_f2(x):
@@ -586,7 +586,7 @@ def _pitzer_f2(x):
     # return 0 if the input is 0
     if x == 0:
         return 0
-    return -2 * (1 - (1 + x + x**2 / 2) * math.exp(-x)) / x**2
+    return -2 * (1 - (1 + x + x**2 / 2) * np.exp(-x)) / x**2
 
 
 def _pitzer_B_MX(ionic_strength, alpha1, alpha2, beta0, beta1, beta2):
@@ -692,7 +692,7 @@ def _pitzer_B_phi(ionic_strength, alpha1, alpha2, beta0, beta1, beta2):
         and Representation with an Ion Interaction (Pitzer) Model.
         Journal of Chemical & Engineering Data, 55(2), 830-838. doi:10.1021/je900487a
     """
-    return beta0 + beta1 * math.exp(-alpha1 * ionic_strength**0.5) + beta2 * math.exp(-alpha2 * ionic_strength**0.5)
+    return beta0 + beta1 * np.exp(-alpha1 * ionic_strength**0.5) + beta2 * np.exp(-alpha2 * ionic_strength**0.5)
 
 
 # def _pitzer_C_MX(C_phi,z_cation,z_anion):
@@ -772,7 +772,7 @@ def _pitzer_log_gamma(
         -1
         * abs(z_cation * z_anion)
         * _debye_parameter_osmotic(temperature)
-        * (ionic_strength**0.5 / (1 + b * ionic_strength**0.5) + 2 / b * math.log(1 + b * ionic_strength**0.5))
+        * (ionic_strength**0.5 / (1 + b * ionic_strength**0.5) + 2 / b * np.log(1 + b * ionic_strength**0.5))
     )
     second_term = 2 * molality * nu_cation * nu_anion / (nu_cation + nu_anion) * (B_MX + B_phi)
     third_term = 3 * molality**2 * (nu_cation * nu_anion) ** 1.5 / (nu_cation + nu_anion) * C_phi

--- a/src/pyEQL/activity_correction.py
+++ b/src/pyEQL/activity_correction.py
@@ -692,7 +692,11 @@ def _pitzer_B_phi(ionic_strength, alpha1, alpha2, beta0, beta1, beta2):
         and Representation with an Ion Interaction (Pitzer) Model.
         Journal of Chemical & Engineering Data, 55(2), 830-838. doi:10.1021/je900487a
     """
-    return beta0 + beta1 * np.exp(-alpha1 * ionic_strength**0.5) + beta2 * np.exp(-alpha2 * ionic_strength**0.5)
+    import math
+
+    # TODO - for some reason this specific method requires the use of math.exp rather than np.exp. Using np.exp raises
+    # a dimensionalityerror.
+    return beta0 + beta1 * math.exp(-alpha1 * ionic_strength**0.5) + beta2 * math.exp(-alpha2 * ionic_strength**0.5)
 
 
 # def _pitzer_C_MX(C_phi,z_cation,z_anion):

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -689,7 +689,7 @@ class NativeEOS(EOS):
         # for any missing species here.
         charge_adjust = 0
         for s in missing_species:
-            charge_adjust += -1 * solution.get_amount(s, "eq/L").magnitude
+            charge_adjust += -1 * solution.get_amount(s, "eq").magnitude
         if charge_adjust != 0:
             logger.warning(
                 "After equilibration, the charge balance of the solution was not electroneutral."
@@ -699,14 +699,12 @@ class NativeEOS(EOS):
             if solution.balance_charge is None:
                 pass
             elif solution.balance_charge == "pH":
-                solution.components["H+"] += charge_adjust * solution.volume.to("L").magnitude
+                solution.components["H+"] += charge_adjust.magnitude
             elif solution.balance_charge == "pE":
                 raise NotImplementedError
             else:
                 z = solution.get_property(solution.balance_charge, "charge")
-                solution.add_amount(
-                    solution.balance_charge, f"{charge_adjust* solution.volume.to('L').magnitude/z} mol"
-                )
+                solution.add_amount(solution.balance_charge, f"{charge_adjust/z} mol")
 
         # rescale the solvent mass to ensure the total mass of solution does not change
         # this is important because PHREEQC and the pyEQL database may use slightly different molecular

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -47,7 +47,7 @@ class EOS(ABC):
             solution: pyEQL Solution object
             solute: str identifying the solute of interest
 
-        Returns
+        Returns:
             Quantity: dimensionless quantity object
 
         Raises:
@@ -62,7 +62,7 @@ class EOS(ABC):
         Args:
             solution: pyEQL Solution object
 
-        Returns
+        Returns:
             Quantity: dimensionless molal scale osmotic coefficient
 
         Raises:
@@ -77,7 +77,7 @@ class EOS(ABC):
         Args:
             solution: pyEQL Solution object
 
-        Returns
+        Returns:
             Quantity: solute volume in L
 
         Raises:
@@ -94,7 +94,7 @@ class EOS(ABC):
         Args:
             solution: pyEQL Solution object
 
-        Returns
+        Returns:
             Nothing. The speciation of the Solution is modified in-place.
 
         Raises:

--- a/src/pyEQL/equilibrium.py
+++ b/src/pyEQL/equilibrium.py
@@ -11,7 +11,8 @@ NOTE: these methods are not currently used but are here for the future.
 
 # import libraries for scientific functions
 import logging
-import math
+
+import numpy as np
 
 from pyEQL import ureg
 
@@ -51,7 +52,7 @@ def adjust_temp_pitzer(c1, c2, c3, c4, c5, temp, temp_ref=ureg.Quantity("298.15 
     return (
         c1
         + c2 * (1 / temp + 1 / temp_ref)
-        + c2 * math.log(temp / temp_ref)
+        + c2 * np.log(temp / temp_ref)
         + c3 * (temp - temp_ref)
         + c4 * (temp**2 - temp_ref**2)
         + c5 * (temp**-2 - temp_ref**-2)
@@ -91,7 +92,7 @@ def adjust_temp_vanthoff(equilibrium_constant, enthalpy, temperature, reference_
         >>> adjust_temp_vanthoff(0.15,ureg.Quantity('-197.6 kJ/mol'),ureg.Quantity('42 degC')) #doctest: +ELLIPSIS
         0.00203566...
     """
-    output = equilibrium_constant * math.exp(
+    output = equilibrium_constant * np.exp(
         enthalpy / ureg.R * (1 / reference_temperature.to("K") - 1 / temperature.to("K"))
     )
 
@@ -137,7 +138,7 @@ def adjust_temp_arrhenius(
         >>> adjust_temp_arrhenius(7,900*ureg.Quantity('kJ/mol'),37*ureg.Quantity('degC'),97*ureg.Quantity('degC')) #doctest: +ELLIPSIS
         1.8867225...e-24
     """
-    output = rate_constant * math.exp(
+    output = rate_constant * np.exp(
         activation_energy / ureg.R * (1 / reference_temperature.to("K") - 1 / temperature.to("K"))
     )
 

--- a/src/pyEQL/functions.py
+++ b/src/pyEQL/functions.py
@@ -7,7 +7,8 @@ pyEQL functions that take Solution objects as inputs or return Solution objects.
 """
 
 import logging
-import math
+
+import numpy as np
 
 from pyEQL import Solution, ureg
 
@@ -55,7 +56,7 @@ def gibbs_mix(solution1: Solution, solution2: Solution):
     for solution in term_list:
         for solute in solution.components:
             if solution.get_amount(solute, "fraction") != 0:
-                term_list[solution] += solution.get_amount(solute, "mol") * math.log(solution.get_activity(solute))
+                term_list[solution] += solution.get_amount(solute, "mol") * np.log(solution.get_activity(solute))
 
     return (ureg.R * blend.temperature.to("K") * (term_list[blend] - term_list[concentrate] - term_list[dilute])).to(
         "J"
@@ -102,7 +103,7 @@ def entropy_mix(solution1: Solution, solution2: Solution):
     for solution in term_list:
         for solute in solution.components:
             if solution.get_amount(solute, "fraction") != 0:
-                term_list[solution] += solution.get_amount(solute, "mol") * math.log(
+                term_list[solution] += solution.get_amount(solute, "mol") * np.log(
                     solution.get_amount(solute, "fraction")
                 )
 
@@ -242,7 +243,7 @@ def donnan_eql(solution: Solution, fixed_charge: str):
 
         return (act_cation_mem / act_cation_soln) ** (1 / z_cation) * (act_anion_soln / act_anion_mem) ** (
             1 / z_anion
-        ) - math.exp(delta_pi * exp_term)
+        ) - np.exp(delta_pi * exp_term)
 
     # solve the function above using one of scipy's nonlinear solvers
 

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -9,7 +9,6 @@ pyEQL Solution Class.
 from __future__ import annotations
 
 import logging
-import math
 import os
 import warnings
 from functools import lru_cache
@@ -434,8 +433,8 @@ class Solution(MSONable):
         """
         try:
             if activity is True:
-                return -1 * math.log10(self.get_activity(solute))
-            return -1 * math.log10(self.get_amount(solute, "mol/L").magnitude)
+                return -1 * np.log10(self.get_activity(solute))
+            return -1 * np.log10(self.get_amount(solute, "mol/L").magnitude)
         # if the solute has zero concentration, the log will generate a ValueError
         except ValueError:
             return 0
@@ -647,7 +646,7 @@ class Solution(MSONable):
         x_cat = self.get_amount(salt.cation, "fraction").magnitude
 
         # calculate the kinematic viscosity
-        nu = math.log(nu_w * MW_w / MW) + 15 * x_cat**2 + x_cat**3 * G_123 + 3 * x_cat * G_23 * (1 - 0.05 * x_cat)
+        nu = np.log(nu_w * MW_w / MW) + 15 * x_cat**2 + x_cat**3 * G_123 + 3 * x_cat * G_23 * (1 - 0.05 * x_cat)
 
         return ureg.Quantity(np.exp(nu), "m**2 / s")
 
@@ -930,9 +929,7 @@ class Solution(MSONable):
             :attr:`dielectric_constant`
 
         """
-        bjerrum_length = ureg.e**2 / (
-            4 * math.pi * self.dielectric_constant * ureg.epsilon_0 * ureg.k * self.temperature
-        )
+        bjerrum_length = ureg.e**2 / (4 * np.pi * self.dielectric_constant * ureg.epsilon_0 * ureg.k * self.temperature)
         return bjerrum_length.to("nm")
 
     @property
@@ -975,7 +972,7 @@ class Solution(MSONable):
         partial_molar_volume_water = self.get_property(self.solvent, "size.molar_volume")
 
         osmotic_pressure = (
-            -1 * ureg.R * self.temperature / partial_molar_volume_water * math.log(self.get_water_activity())
+            -1 * ureg.R * self.temperature / partial_molar_volume_water * np.log(self.get_water_activity())
         )
         self.logger.debug(
             f"Calculated osmotic pressure of solution as {osmotic_pressure} Pa at T= {self.temperature} degrees C"
@@ -1835,12 +1832,12 @@ class Solution(MSONable):
                 * ureg.Quantity(0.018015, "kg/mol")
                 * self.get_total_moles_solute()
                 / self.solvent_mass
-                / math.log(self.get_amount(self.solvent, "fraction"))
+                / np.log(self.get_amount(self.solvent, "fraction"))
             )
         if scale == "fugacity":
             return np.exp(
                 -molal_phi * ureg.Quantity(0.018015, "kg/mol") * self.get_total_moles_solute() / self.solvent_mass
-                - math.log(self.get_amount(self.solvent, "fraction"))
+                - np.log(self.get_amount(self.solvent, "fraction"))
             ) * ureg.Quantity(1, "dimensionless")
 
         raise ValueError("Invalid scale argument. Pass 'molal', 'rational', or 'fugacity'.")
@@ -1939,14 +1936,14 @@ class Solution(MSONable):
                         ureg.R
                         * self.temperature.to("K")
                         * self.get_amount(item, "mol")
-                        * math.log(self.get_activity(item))
+                        * np.log(self.get_activity(item))
                     )
                 else:
                     E += (
                         ureg.R
                         * self.temperature.to("K")
                         * self.get_amount(item, "mol")
-                        * math.log(self.get_amount(item, "fraction"))
+                        * np.log(self.get_amount(item, "fraction"))
                     )
             # If we have a solute with zero concentration, we will get a ValueError
             except ValueError:
@@ -2582,12 +2579,12 @@ class Solution(MSONable):
             "this property is planned for a future release."
         )
         # calculate the new pH and pE (before reactions) by mixing
-        mix_pH = -math.log10(float(mix_species["H+"].split(" ")[0]) / mix_vol.to("L").magnitude)
+        mix_pH = -np.log10(float(mix_species["H+"].split(" ")[0]) / mix_vol.to("L").magnitude)
 
         # pE = -log[e-], so calculate the moles of e- in each solution and mix them
         mol_e_self = 10 ** (-1 * self.pE) * self.volume.to("L").magnitude
         mol_e_other = 10 ** (-1 * other.pE) * other.volume.to("L").magnitude
-        mix_pE = -math.log10((mol_e_self + mol_e_other) / mix_vol.to("L").magnitude)
+        mix_pE = -np.log10((mol_e_self + mol_e_other) / mix_vol.to("L").magnitude)
 
         # create a new solution
         return Solution(

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -432,9 +432,13 @@ class Solution(MSONable):
                 activity = False) of the solute.
         """
         try:
+            # TODO - for some reason this specific method requires the use of math.log10 rather than np.log10.
+            # Using np.exp raises ZeroDivisionError
+            import math
+
             if activity is True:
-                return -1 * np.log10(self.get_activity(solute))
-            return -1 * np.log10(self.get_amount(solute, "mol/L").magnitude)
+                return -1 * math.log10(self.get_activity(solute))
+            return -1 * math.log10(self.get_amount(solute, "mol/L").magnitude)
         # if the solute has zero concentration, the log will generate a ValueError
         except ValueError:
             return 0


### PR DESCRIPTION
## Summary

Fixes #141 . This was ultimately caused by a subtle problem with charge balancing when elements with multiple oxidation states (at least, as recognized by `oxi_state_guesses`) were present in the `Solution`.