### PR TITLE
DB: add missing units to radius_ionic for Cr+3 and Ni+2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Database: `size.radius_ionic` was missing units for `Ni[+2]` and `Cr[+3]`. Correct units have been added.
+
 ## [1.0.3] - 2024-07-20
 
 ### Fixed

--- a/src/pyEQL/database/pyeql_db.json
+++ b/src/pyEQL/database/pyeql_db.json
@@ -6698,7 +6698,7 @@
         "n_elements": 1,
         "size": {
             "radius_ionic": {
-                "value": "0.755",
+                "value": "0.755 Å",
                 "reference": "pymatgen",
                 "data_type": "experimental"
             },
@@ -24663,7 +24663,7 @@
         "n_elements": 1,
         "size": {
             "radius_ionic": {
-                "value": "0.83",
+                "value": "0.83 Å",
                 "reference": "pymatgen",
                 "data_type": "experimental"
             },


### PR DESCRIPTION
the `size.radius_ionic` for `Cr[+3]` and `Ni[+2]` was missing units. This PR adds them.