### PR TITLE
bump ver to 1.1.1 for PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - 2024-07-27
+## [1.1.1] - 2024-07-27
 
 ### Fixed
 


### PR DESCRIPTION
This is to work around an erroneous (now deleted) v1.1.0 release a few weeks back, since PyPi doesn't allow reuse of filenames.