### PR TITLE
Solution: fix pH charge balancing bug and possible water ion imbalance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2024-07-28
+
+### Fixed
+
+- `Solution`: Fix a bug in which setting `balance_charge` to `pH` could result in
+  negative concentration errors when charge balancing or after `equilibrate` was
+  called. `Solution` now correctly enforces the ion product of water (Kw=1e-14)
+  whenever adjusting the amounts of H+ or OH- for charge balancing.
+
+### Added
+
+- `Solution._adjust_charge_balance`: Added a privat helper method to consolidate charge
+  balancing code used in `__init__` and `equilibrate`.
+
 ## [1.1.2] - 2024-07-28
 
 ### Fixed

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -687,20 +687,8 @@ class NativeEOS(EOS):
             )
 
         # re-adjust charge balance for any missing species
-        # note that if balance_charge is set, it will have been passed to PHREEQC, so we only need to adjust
-        # for any missing species here.
-        charge_adjust = 0
-        for s in missing_species:
-            charge_adjust += -1 * solution.get_amount(s, "eq").magnitude
-        if charge_adjust != 0:
-            logger.warning(
-                "After equilibration, the charge balance of the solution was not electroneutral."
-                f" {charge_adjust} eq of charge were added via {solution._cb_species}"
-            )
-
-            if solution.balance_charge is not None:
-                z = solution.get_property(solution._cb_species, "charge")
-                solution.add_amount(solution._cb_species, f"{charge_adjust/z} mol")
+        # note that if balance_charge is set, it will have been passed to PHREEQC, so the only reason to re-adjust charge balance here is to account for any missing species.
+        solution._adjust_charge_balance()
 
         # rescale the solvent mass to ensure the total mass of solution does not change
         # this is important because PHREEQC and the pyEQL database may use slightly different molecular

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -202,8 +202,8 @@ def test_init_engines():
 
 
 def test_component_subsets(s2):
-    assert s2.cations == {"Na[+1]": 8, "H[+1]": 2e-7}
-    assert s2.anions == {"Cl[-1]": 8, "OH[-1]": 2e-7}
+    assert list(s2.cations.keys()) == ["Na[+1]", "H[+1]"]
+    assert list(s2.anions.keys()) == ["Cl[-1]", "OH[-1]"]
     assert list(s2.neutrals.keys()) == ["H2O(aq)"]
 
 
@@ -283,6 +283,28 @@ def test_charge_balance(s3, s5, s5_pH, s6, s6_Ca):
     s.equilibrate()
     assert s.balance_charge == "auto"
     assert s._cb_species == "Cl[-1]"
+    assert np.isclose(s.charge_balance, 0, atol=1e-8)
+
+    # check 'pH' when the solution needs to be made more POSITIVE
+    s = Solution({"Na+": "2 mM", "Cl-": "1 mM"}, balance_charge="pH", pH=4)
+    assert s.balance_charge == "pH"
+    assert s._cb_species == "H[+1]"
+    assert np.isclose(s.charge_balance, 0, atol=1e-8)
+    assert s.pH > 4
+    s.equilibrate()
+    assert s.balance_charge == "pH"
+    assert s._cb_species == "H[+1]"
+    assert np.isclose(s.charge_balance, 0, atol=1e-8)
+
+    # check 'pH' when the imbalance is extreme
+    s = Solution({"Na+": "2 mM", "Cl-": "1 M"}, balance_charge="pH", pH=4)
+    assert s.balance_charge == "pH"
+    assert s._cb_species == "H[+1]"
+    assert np.isclose(s.charge_balance, 0, atol=1e-8)
+    assert np.isclose(s.pH, 0, atol=0.1)
+    s.equilibrate()
+    assert s.balance_charge == "pH"
+    assert s._cb_species == "H[+1]"
     assert np.isclose(s.charge_balance, 0, atol=1e-8)
 
     # check "auto" with an electroneutral solution
@@ -405,16 +427,16 @@ def test_components_by_element(s1, s2):
     assert s1.get_components_by_element() == {
         "H(1.0)": [
             "H2O(aq)",
-            "H[+1]",
             "OH[-1]",
+            "H[+1]",
         ],
         "O(-2.0)": ["H2O(aq)", "OH[-1]"],
     }
     assert s2.get_components_by_element() == {
         "H(1.0)": [
             "H2O(aq)",
-            "H[+1]",
             "OH[-1]",
+            "H[+1]",
         ],
         "O(-2.0)": ["H2O(aq)", "OH[-1]"],
         "Na(1.0)": ["Na[+1]"],
@@ -498,8 +520,8 @@ def test_equilibrate(s1, s2, s5_pH):
     orig_solv_mass = s5_pH.solvent_mass.magnitude
     set(s5_pH.components.keys())
     s5_pH.equilibrate()
-    assert np.isclose(s5_pH.get_total_amount("Ca", "mol").magnitude, 0.001)
-    assert np.isclose(s5_pH.get_total_amount("C(4)", "mol").magnitude, 0.001)
+    assert np.isclose(s5_pH.get_total_amount("Ca", "mol").magnitude, 0.001, atol=1e-7)
+    assert np.isclose(s5_pH.get_total_amount("C(4)", "mol").magnitude, 0.001, atol=1e-7)
     # due to the large pH shift, water mass and density need not be perfectly conserved
     assert np.isclose(s5_pH.solvent_mass.magnitude, orig_solv_mass, atol=1e-3)
     assert np.isclose(s5_pH.density.magnitude, orig_density, atol=1e-3)

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -307,6 +307,10 @@ def test_charge_balance(s3, s5, s5_pH, s6, s6_Ca):
     assert s._cb_species == "H[+1]"
     assert np.isclose(s.charge_balance, 0, atol=1e-8)
 
+    # check warning when there isn't enough to balance
+    s = Solution({"Na+": "1 M", "K+": "2 mM", "Cl-": "2 mM"}, balance_charge="K+")
+    assert s.get_amount("K+", "mol/L") == 0
+
     # check "auto" with an electroneutral solution
     s = Solution({"Na+": "2 mM", "Cl-": "2 mM"}, balance_charge="auto")
     assert s.balance_charge == "auto"


### PR DESCRIPTION
## [1.1.3] - 2024-07-28

### Fixed

- `Solution`: Fix a bug in which setting `balance_charge` to `pH` could result in
  negative concentration errors when charge balancing or after `equilibrate` was
  called. `Solution` now correctly enforces the ion product of water (Kw=1e-14)
  whenever adjusting the amounts of H+ or OH- for charge balancing.

### Added

- `Solution._adjust_charge_balance`: Added a privat helper method to consolidate charge
  balancing code used in `__init__` and `equilibrate`.