### PR TITLE
Hotfix v1.1.5 - remove stray assert statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2024-07-28
+
+### Fixed
+
+- `Solution`: Hotfix to remove a stray `assert` statement in `_adjust_charge_balance`
+  that would sometimes cause errors in`pH` charge balancing.
+
 ## [1.1.4] - 2024-07-28
 
 ### Fixed

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -2316,7 +2316,6 @@ class Solution(MSONable):
                 )
                 self.set_amount("H+", f"{new_hplus} mol/L")
                 self.set_amount("OH-", f"{K_W/new_hplus} mol/L")
-                assert np.isclose(self.charge_balance, 0, atol=atol), f"{self.charge_balance}"
                 return
 
             z = self.get_property(self._cb_species, "charge")


### PR DESCRIPTION
## [1.1.5] - 2024-07-28

### Fixed

- `Solution`: Hotfix to remove a stray `assert` statement in `_adjust_charge_balance`
  that would sometimes cause errors in`pH` charge balancing.