### PR TITLE
Refactor logging for `_adjust_charge_balance`

### DIFF
--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -2295,7 +2295,7 @@ class Solution(MSONable):
                 return
 
             self.logger.info(
-                f"Solution is not electroneutral (C.B. = {cb} eq/L). Adjusting {self._cb_species} to compensate."
+                f"Adjusting {self._cb_species} to compensate."
             )
 
             if self.balance_charge == "pH":


### PR DESCRIPTION
## Refactor logging for `_adjust_charge_balance`

Description: 
- Edited the log message at `line 2298` to remove the redundant log message “Solution is not electroneutral (C.B. = {cb} eq/L).”

Minor changes:
- Updated the log message at `line 2298` to `self.logger.info(f"Adjusting {self._cb_species} to compensate.")`
- The separate log message at `line 2291` remains as `self.logger.info(f"Solution is not electroneutral (C.B. = {cb} eq/L).")`
