### PR TITLE
add lowest-direct dependency resolution

### DIFF
--- a/.github/workflows/post-process.yml
+++ b/.github/workflows/post-process.yml
@@ -33,7 +33,11 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        version:
+          - { python: "3.9", resolution: highest, extras: strict }
+          - { python: "3.10", resolution: lowest-direct, extras: strict }
+          - { python: "3.11", resolution: highest, extras: non-strict }
+          - { python: "3.12", resolution: lowest-direct, extras: non-strict }
         os:
           - ubuntu-latest
           - macos-latest
@@ -48,7 +52,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}${{ matrix.dev }}
+          python-version: ${{ matrix.version.python }}${{ matrix.dev }}
       - name: Install test requirements
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary

Major changes:

- feature 1: add dependency instead of only python versions
- fix 1: 
```
        version:
          - { python: "3.9", resolution: highest, extras: strict }
          - { python: "3.10", resolution: lowest-direct, extras: strict }
          - { python: "3.11", resolution: highest, extras: non-strict }
          - { python: "3.12", resolution: lowest-direct, extras: non-strict }
```
instead of: `python-version: ['3.9', '3.10', '3.11']`

similar to in https://github.com/materialsproject/jobflow/pull/640#issuecomment-2245947952

## Todos

If this is not the right approach, @rkingsbury please let me know

