### PR TITLE
Set minimum iapws >1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
         "numpy<2",
         "scipy",
         "pymatgen==2024.5.1",
-        "iapws",
+        "iapws>=1.0.1",
         "monty>=2024.7.12",
         "maggma>=0.67.0",
         "phreeqpython",


### PR DESCRIPTION
Guarantee minimum `iapws` version is 1.0.1 b/c 1.0.0 has a packaging problem and is not installable.