### PR TITLE
pin pytest>=7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ Package = "https://pypi.org/project/pyEQL"
 testing = [
     "setuptools",
     "pre-commit",
-    "pytest",
+    "pytest>=7",
     "pytest-cov",
     "pytest-xdist",
     "black",


### PR DESCRIPTION
Another installation problem when using `lowest-direct` dependency resolution