### PR TITLE
set minimum dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
         "iapws>=1.5.3",
         "monty>=2024.7.12",
         "maggma>=0.67.0",
-        "phreeqpython>=1.4",
+        "phreeqpython>=1.5",
     ]
 
 [project.urls]


### PR DESCRIPTION
See #172 . `uv pip install --resolution=lowest-direct` now passes locally but not in CI. Hopefully this bump will fix.