### PR TITLE
Revise 'Mixing Functions' documentation

### DIFF
--- a/src/pyEQL/functions.py
+++ b/src/pyEQL/functions.py
@@ -34,7 +34,7 @@ def gibbs_mix(solution1: Solution, solution2: Solution):
 
             \Delta_{mix} G = \sum_i {(n_c + n_d) R T \ln a_b} - \sum_i {n_c R T \ln a_c} - \sum_i {n_d R T \ln a_d}
 
-        Where :math:`n` is the number of moles of substance, :math:`T` is the temperature in kelvin,
+        Where :math:`n` is the number of moles of substance, :math:`T` is the temperature in kelvin, :math:`a` is the activity of substance,
         and  subscripts :math:`b`, :math:`c`, and :math:`d` refer to the concentrated, dilute, and blended
         Solutions, respectively.
 
@@ -72,16 +72,16 @@ def entropy_mix(solution1: Solution, solution2: Solution):
 
     Returns:
         The ideal mixing entropy associated with complete mixing of the
-        Solutions, in Joules.
+        Solutions, in Joules per Kelvin.
 
     Notes:
         The ideal entropy of mixing is calculated as follows
 
         .. math::
 
-            \Delta_{mix} S = \sum_i {(n_c + n_d) R T \ln x_b} - \sum_i {n_c R T \ln x_c} - \sum_i {n_d R T \ln x_d}
+            \Delta_{mix} S = \sum_i {(n_c + n_d) R \ln x_b} - \sum_i {n_c R \ln x_c} - \sum_i {n_d R \ln x_d}
 
-        Where :math:`n` is the number of moles of substance, :math:`T` is the temperature in kelvin,
+        Where :math:`n` is the number of moles of substance, :math:`T` is the temperature in kelvin, :math:`x` is the molar ratio of substances,
         and  subscripts :math:`b`, :math:`c`, and :math:`d` refer to the concentrated, dilute, and blended
         Solutions, respectively.
 
@@ -135,9 +135,9 @@ def donnan_eql(solution: Solution, fixed_charge: str):
 
         .. math::
 
-            \big(\frac{a_{-}}{\bar a_{-}} \big)^(\frac{1}{z_{-})
-            \big(\frac{\bar a_{+}}{a_{+}}\big)^(\frac{1}{z_{+})
-            \exp(\frac{\Delta \pi \bar V}{RT z_{+} \nu_{+}})
+            \big(\frac{a_{-}}{\bar a_{-}} \big)^{(\frac{1}{z_{-}})} 
+            \big(\frac{\bar a_{+}}{a_{+}}\big)^{(\frac{1}{z_{+}})}
+            =\exp \big(\frac{\Delta \pi \bar V}{RT z_{+} \nu_{+}}\big)
 
         Where subscripts :math:`+` and :math:`-` indicate the cation and anion, respectively,
         the overbar indicates the membrane phase,

--- a/src/pyEQL/functions.py
+++ b/src/pyEQL/functions.py
@@ -64,15 +64,12 @@ def gibbs_mix(solution1: Solution, solution2: Solution, activity_correction: boo
     term_list = {concentrate: 0, dilute: 0, blend: 0}
 
     # calculate the entropy change and number of moles solute for each solution
-    if activity_correction is True:
-        for solution in term_list:
-            for solute in solution.components:
-                if solution.get_amount(solute, "fraction") != 0:
+    for solution in term_list:
+        for solute in solution.components:
+            if solution.get_amount(solute, "fraction") != 0:
+                if activity_correction is True:
                     term_list[solution] += solution.get_amount(solute, "mol") * np.log(solution.get_activity(solute))
-    else:
-        for solution in term_list:
-            for solute in solution.components:
-                if solution.get_amount(solute, "fraction") != 0:
+                else:
                     term_list[solution] += solution.get_amount(solute, "mol") * np.log(solution.get_amount(solute, "fraction"))
 
     return (ureg.R * blend.temperature.to("K") * (term_list[blend] - term_list[concentrate] - term_list[dilute])).to(

--- a/src/pyEQL/functions.py
+++ b/src/pyEQL/functions.py
@@ -73,7 +73,7 @@ def gibbs_mix(solution1: Solution, solution2: Solution, activity_correction: boo
         for solution in term_list:
             for solute in solution.components:
                 if solution.get_amount(solute, "fraction") != 0:
-                    term_list[solution] += solution.get_amount(solute, "mol") * np.log(solution.get_amount(item, "fraction"))
+                    term_list[solution] += solution.get_amount(solute, "mol") * np.log(solution.get_amount(solute, "fraction"))
 
     return (ureg.R * blend.temperature.to("K") * (term_list[blend] - term_list[concentrate] - term_list[dilute])).to(
         "J"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -18,7 +18,7 @@ def s1():
 
 @pytest.fixture()
 def s2():
-    return Solution({"Na+": "1 mol/L", "Cl": "1 mol/L"}, volume="10 L")
+    return Solution({"Na+": "1 mol/L", "Cl-": "1 mol/L"}, volume="10 L")
 
 
 @pytest.fixture()

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -18,7 +18,7 @@ def s1():
 
 @pytest.fixture()
 def s2():
-    return Solution({"Na+": "1 mol/L", "Cl-": "1 mol/L"}, volume="10 L")
+    return Solution({"Na+": "1 mol/L", "Cl": "1 mol/L"}, volume="10 L")
 
 
 @pytest.fixture()
@@ -57,7 +57,6 @@ def test_mixing_functions(s1, s2, s1_p, s2_p, s1_i, s2_i):
         # H20: 55.5 * 2 mol + 55.5 * 10 mol, x1 = 0.9999 x2 = 0.9645, mixture = 0.9703 = approximately -9043 J
         s_theoretical = (
             8.314
-            * 298.15
             * (
                 (dil + conc).get_amount("H2O", "mol").magnitude
                 * np.log((dil + conc).get_amount("H2O", "fraction").magnitude)
@@ -72,7 +71,24 @@ def test_mixing_functions(s1, s2, s1_p, s2_p, s1_i, s2_i):
             )
         )
         assert np.isclose(entropy_mix(dil, conc).magnitude, s_theoretical, rtol=0.005)
-        g_theoretical = (
+        g_ideal_theoretical = (
+            8.314
+            * 298.15
+            * (
+                (dil + conc).get_amount("H2O", "mol").magnitude
+                * np.log((dil + conc).get_amount("H2O", "fraction").magnitude)
+                + (dil + conc).get_amount("Na+", "mol").magnitude
+                * np.log((dil + conc).get_amount("Na+", "fraction").magnitude)
+                + (dil + conc).get_amount("Cl-", "mol").magnitude
+                * np.log((dil + conc).get_amount("Cl-", "fraction").magnitude)
+                - dil.get_amount("H2O", "mol").magnitude * np.log(dil.get_amount("H2O", "fraction").magnitude)
+                - conc.get_amount("H2O", "mol").magnitude * np.log(conc.get_amount("H2O", "fraction").magnitude)
+                - conc.get_amount("Na+", "mol").magnitude * np.log(conc.get_amount("Na+", "fraction").magnitude)
+                - conc.get_amount("Cl-", "mol").magnitude * np.log(conc.get_amount("Cl-", "fraction").magnitude)
+            )
+        )
+        assert np.isclose(gibbs_mix(dil, conc, False).magnitude, g_ideal_theoretical, rtol=0.005)
+        g_true_theoretical = (
             8.314
             * 298.15
             * (
@@ -85,4 +101,4 @@ def test_mixing_functions(s1, s2, s1_p, s2_p, s1_i, s2_i):
                 - conc.get_amount("Cl-", "mol").magnitude * np.log(conc.get_activity("Cl-").magnitude)
             )
         )
-        assert np.isclose(gibbs_mix(dil, conc).magnitude, g_theoretical, rtol=0.005)
+        assert np.isclose(gibbs_mix(dil, conc).magnitude, g_true_theoretical, rtol=0.005)


### PR DESCRIPTION
## Summary

Major changes:

- feature 1: Revise 'Mixing Functions' documentation
- fix 1: Remove `T` from mixing entropy equation
- fix 2: Add explanations of activity and molar ratio for Gibbs free energy and entropy equation, respectively
- fix 3: Revise the unit of mixing entropy from `Joules` to `Joules per Kelvin`
- fix 4: Correct the error that prevents the formula from being displayed in the `donnan_eql()` documentation.