### PR TITLE
Bugfix in get_total_amount; CHANGELOG for next version

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,9 +5,11 @@ developed and maintained by the Kingsbury Lab at Princeton University.
 
 Other contributors, listed alphabetically, are:
 
-* Kirill Pushkarev (@kirill-push)
-* Dhruv Duseja (@DhruvDuseja)
-* Andrew Rosen (@arosen93)
-* Hernan Grecco (@hgrecco)
+- Arpit Bhardwaj (@abhardwaj73)
+- Dhruv Duseja (@DhruvDuseja)
+- Jaebeom Park (@Jaebeom-P)
+- Kirill Pushkarev (@kirill-push)
+- Andrew Rosen (@arosen93)
+- Hernan Grecco (@hgrecco)
 
 (If you think that your name belongs here, please let the maintainer know)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,9 +7,10 @@ Other contributors, listed alphabetically, are:
 
 - Arpit Bhardwaj (@abhardwaj73)
 - Dhruv Duseja (@DhruvDuseja)
+- Hernan Grecco (@hgrecco)
 - Jaebeom Park (@Jaebeom-P)
 - Kirill Pushkarev (@kirill-push)
 - Andrew Rosen (@arosen93)
-- Hernan Grecco (@hgrecco)
+- Sui Xiong Tay (@SuixiongTay)
 
 (If you think that your name belongs here, please let the maintainer know)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2024-09-01
+
+### Fixed
+
+- `Solution.get_total_amount`: Bugfix that caused an error when called on certain elements
+  without specifying an oxidation state. For example, `get_total_amount('N')` could raise
+  an exception in a solution containing `Na` (but no `N`) due to a flaw in a logical
+  test.
+
 ## [1.1.5] - 2024-07-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an exception in a solution containing `Na` (but no `N`) due to a flaw in a logical
   test.
 
+### Added
+
+- `gibbs_mix`: A new keyword argument `activity_correction` was added to `gibbs_mix`. It defaults
+  to `True` (no change from prior behavior), but can be set to `False` in order to calculate the
+  ideal mixing energy, which is equivalent to only considering entropic effects. (#178, @Jaebeom-P)
+
+### Changed
+
+- **BREAKING** `entropy_mix` now returns the ideal mixing _entropy_ in units of J/K rather than the mixing
+  _energy_ in J. This was done to improve clarity with respect to the function name. An `activity_correction`
+  kwarg was added to `gibbs_mix` so that you can still calculate the ideal mixing energy by setting it to `False`.
+  (#178, @Jaebeom-P)
+- Revise documentation of `gibbs_mix`, `entropy_mix`, and `donnan_eql`. (#178, @Jaebeom-P)
+- CI: Improve comprehensiveness of CI dependency testing. (#163, #164, @abhardwaj73)
+
 ## [1.1.5] - 2024-07-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gibbs_mix`: A new keyword argument `activity_correction` was added to `gibbs_mix`. It defaults
   to `True` (no change from prior behavior), but can be set to `False` in order to calculate the
   ideal mixing energy, which is equivalent to only considering entropic effects. (#178, @Jaebeom-P)
+- `standardize_formula`: Improve formatting of ammonium sulfate salts. Aqueous ammonium sulfate previously
+  standardized to `H8S(NO2)2(aq)`, now it will display as `(NH4)2SO4(aq)`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without specifying an oxidation state. For example, `get_total_amount('N')` could raise
   an exception in a solution containing `Na` (but no `N`) due to a flaw in a logical
   test.
+- `Solution._adjust_charge_balance`: Removed a misleading and redundant log message (#162, @SuixiongTay)
 
 ### Added
 

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -1161,7 +1161,8 @@ class Solution(MSONable):
             :meth:`get_amount`
             :func:`pyEQL.utils.interpret_units`
         """
-        TOT: Quantity = 0
+        _units = interpret_units(units)
+        TOT: Quantity = ureg.Quantity(0, _units)
 
         # standardize the element formula and units
         el = str(Element(element.split("(")[0]))
@@ -1178,7 +1179,7 @@ class Solution(MSONable):
         else:
             species = []
             for k, v in comp_by_element.items():
-                if el in k:
+                if k.split("(")[0] == el:
                     species.extend(v)
 
         # loop through the species of interest, adding moles of element
@@ -2294,9 +2295,7 @@ class Solution(MSONable):
                 self.logger.info("balance_charge is None, so no charge balancing will be performed.")
                 return
 
-            self.logger.info(
-                f"Adjusting {self._cb_species} to compensate."
-            )
+            self.logger.info(f"Adjusting {self._cb_species} to compensate.")
 
             if self.balance_charge == "pH":
                 # the charge imbalance associated with the H+ / OH- system can be expressed

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -137,6 +137,12 @@ def standardize_formula(formula: str):
     elif sform == "C2I2ClO2[-1]":
         sform = "CI2ClCOO[-1]"
 
+    # ammonium sulfate salts
+    elif sform == "H8S(NO2)2(aq)":
+        sform = "(NH4)2SO4(aq)"
+    elif sform == "H4SNO4[-1]":
+        sform = "NH4SO4[-1]"
+
     # TODO - consider adding recognition of special formulas like MeOH for methanol or Cit for citrate
     return sform
 

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -476,6 +476,7 @@ def test_components_by_element(s1, s2):
 def test_get_total_amount(s2):
     assert np.isclose(s2.get_total_amount("Na(1)", "g").magnitude, 8 * 58, 44)
     assert np.isclose(s2.get_total_amount("Na", "mol").magnitude, 8)
+    assert np.isclose(s2.get_total_amount("N", "mol").magnitude, 0)
     assert np.isclose(s2.get_total_amount("Na", "ppm").magnitude, 4 * 23300, rtol=0.02)
     sox = Solution({"Fe+2": "10 mM", "Fe+3": "40 mM", "Cl-": "50 mM"}, pH=3)
     assert np.isclose(sox.get_total_amount("Fe(2)", "mol/L").magnitude, 0.01)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,6 +52,8 @@ def test_standardize_formula():
     # Cl+Br
     assert standardize_formula("CBrCl2COO-") == "CBrCl2COO[-1]"
     assert standardize_formula("CBr2ClCOO-") == "CBr2ClCOO[-1]"
+    assert standardize_formula("(NH4)2SO4") == "(NH4)2SO4(aq)"
+    assert standardize_formula("NH4SO4-") == "NH4SO4[-1]"
 
 
 def test_formula_dict():


### PR DESCRIPTION
## Summary

Fixes a subtle bug that caused `get_total_amount` to fail when passed an element with no oxidation state (such as `N`) that also occurs as part of another element name (such as `Na`)

Also improves formatting of ammonium sulfate salts in `standardize_formula`.
