### PR TITLE
Documentation minor fixes

### DIFF
--- a/docs/class_solution.md
+++ b/docs/class_solution.md
@@ -10,7 +10,7 @@ This page contains detailed information on each of the methods, attributes, and 
 .. autoclass:: pyEQL.Solution
    :members:
    :inherited-members:
-   :private-members: _get_property, _get_diffusion_coefficient, _get_molar_conductivity
+   :private-members: _get_property, _get_diffusion_coefficient, _get_molar_conductivity, _get_mobility
    :special-members: __init__
    :member-order: bysource
 ```

--- a/docs/class_solution.md
+++ b/docs/class_solution.md
@@ -10,7 +10,7 @@ This page contains detailed information on each of the methods, attributes, and 
 .. autoclass:: pyEQL.Solution
    :members:
    :inherited-members:
-   :private-members: _get_property
+   :private-members: _get_property, _get_diffusion_coefficient, _get_molar_conductivity
    :special-members: __init__
    :member-order: bysource
 ```


### PR DESCRIPTION
## Summary

Changes:

- Fixes #195 

## Checklist

- [ ] Google format doc strings added.
- [ ] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] I have run the tests locally and they passed.
<!-- - [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) -->

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
