### PR TITLE
CI: don't fail on FutureWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ norecursedirs = [
   ".tox",
 ]
 xfail_strict = true
-filterwarnings = ["error", "ignore::UserWarning", "ignore::DeprecationWarning"]
+filterwarnings = ["error", "ignore::UserWarning", "ignore::DeprecationWarning", "ignore::FutureWarning"]
 log_cli_level = "warning"
 testpaths = [
   "tests",


### PR DESCRIPTION
our `pytest` configuration uses `filterwarnings` to turn most warnings into errors, but `FutureWarning` should not be included in that behavior.