### PR TITLE
bump pint to 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Bump `pint` to `0.24.1` for `numpy` `v2.0` compatibility and to mitigate CI issues (@SuixiongTay, @rkingsbury)
+- CI: add `python` `v3.13` to post-merge unit tests
+
 ## [1.2.0] - 2024-09-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Support `numpy>2.0`
 - Bump `pint` to `0.24.1` for `numpy` `v2.0` compatibility and to mitigate CI issues (@SuixiongTay, @rkingsbury)
 - CI: add `python` `v3.13` to post-merge unit tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers=[
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
 dependencies = [
-        "pint>=0.24",
+        "pint>=0.24.1",
         "numpy>1.26",
         "scipy>=1.12",
         "pymatgen>=2024.9.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ classifiers=[
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
 dependencies = [
-        "pint>=0.19",
-        "numpy>1.26,<2",
+        "pint>=0.24",
+        "numpy>1.26",
         "scipy>=1.12",
         "pymatgen>=2024.9.10",
         "iapws>=1.5.3",


### PR DESCRIPTION
- Bump `pint` to `0.24.1` for `numpy` `v2.0` compatibility and to mitigate CI issues