### PR TITLE
Using importlib to locate seawater.yaml

### DIFF
--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -13,6 +13,7 @@ import platform
 import numpy as np
 import pytest
 import yaml
+from importlib.resources import files
 
 from pyEQL import Solution, ureg
 from pyEQL.engines import IdealEOS, NativeEOS
@@ -743,9 +744,10 @@ def test_from_preset(tmp_path):
 
     preset_name = "seawater"
     solution = Solution.from_preset(preset_name)
-    with open(os.path.join("src/pyEQL/presets", f"{preset_name}.yaml")) as file:
+    preset_path = files("pyEQL") / "presets" / "seawater.yaml"
+    
+    with open(str(preset_path), "r") as file:
         data = yaml.load(file, Loader=yaml.FullLoader)
-    # test valid preset
     assert isinstance(solution, Solution)
     assert solution.temperature.to("degC") == ureg.Quantity(data["temperature"])
     assert solution.pressure == ureg.Quantity(data["pressure"])


### PR DESCRIPTION
## Summary

- Used `importlib` to locate `seawater.yaml`.