### PR TITLE
Update pre commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 exclude: "^docs/conf.py"
 
-default_stages: [commit]
+default_stages: [pre-commit]
 
 default_install_hook_types: [pre-commit, commit-msg]
 
@@ -30,7 +30,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-        stages: [commit, commit-msg]
+        stages: [pre-commit, commit-msg]
         exclude_types: [html, svg]
         additional_dependencies: [tomli] # needed to read pyproject.toml below py3.11
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.7
+    rev: v0.12.0
     hooks:
       # Run the linter. filters are to exclude .ipynb files
       - id: ruff
@@ -22,12 +22,12 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
+    rev: 25.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         stages: [pre-commit, commit-msg]
@@ -35,7 +35,7 @@ repos:
         additional_dependencies: [tomli] # needed to read pyproject.toml below py3.11
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-case-conflict
       - id: check-symlinks


### PR DESCRIPTION
## Summary

Major changes:

closes #257 

- updates syntax used in `.pre-commit-config.yaml` for pre-commit hooks
- updates pre-commit hook versions for black, codespell, ruff, pre-commit using `pre-commit autoupdate`

## Todos

- [X] Google format doc strings added.
- [X] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] I have run the tests locally and they passed.