### PR TITLE
bump maggma to v0.71.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
         "pymatgen>=2024.9.10",
         "iapws>=1.5.3",
         "monty>=2024.12.10",
-        "maggma>=0.67.0",
+        "maggma>=0.71.4",
         "phreeqpython>=1.5.2",
     ]
 


### PR DESCRIPTION
This is needed b/c 0.71.4 is the first version that explicitly pins pymongo to <4.11. Without the pin, there is an error due to mongomock not supporting the 'sort' operator. See https://github.com/mongomock/mongomock/issues/912