### PR TITLE
bump pymatgen to v2025.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docs: `tox -e docs` command configured to fail on warning (#255, ugognw)
 - Docs: ReadTheDocs built with Python 3.11 (#255, ugognw)
 - Use `importlib` to locate test files (#241, @SuixiongTay)
+- bump `pymatgen` to `v2025.1.9`
+- bump `maggma` to `v0.71.4`
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
         "pint>=0.24.4",
         "numpy>1.26",
         "scipy>=1.12",
-        "pymatgen>=2024.9.10",
+        "pymatgen>=2025.1.9",
         "iapws>=1.5.3",
         "monty>=2024.12.10",
         "maggma>=0.71.4",


### PR DESCRIPTION
bump pymatgen to v.2025.1.9 to avoid a `DeprecationWarning` from causing the CI tests (post-merge) to fail.