### PR TITLE
standardize_formula: handle ambiguous dash-hyphens pt.2

### DIFF
--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -73,7 +73,7 @@ def standardize_formula(formula: str):
         formula = formula.replace(char, rep)
 
     # replace different types of dashes with a minus sign
-    for char in [r"‑", r"‐", r"‒", r"–", r"—"]:  # noqa: RUF001
+    for char in [r"‑", r"‐", r"‒", r"–", r"—", r"−"]:  # noqa: RUF001
         formula = formula.replace(char, "-")
 
     sform = Ion.from_formula(formula).reduced_formula

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,7 @@ def test_standardize_formula():
     assert standardize_formula("Mg⁺²") == "Mg[+2]"
     assert standardize_formula("VO²⁺") == "VO[+2]"
     assert standardize_formula("SO₄²⁻") == "SO4[-2]"
-    for dash in ["‑", "‐", "‒", "–", "—"]:  # noqa: RUF001
+    for dash in ["‑", "‐", "‒", "–", "—", "−"]:  # noqa: RUF001
         assert standardize_formula(f"Cl{dash}") == "Cl[-1]"
 
     assert standardize_formula("H2O") == "H2O(aq)"


### PR DESCRIPTION
Follow up to #264 . The previous PR did not include the character U+2212