### PR TITLE
Fix mass conservation for H+ and OH- in Solution.__add__ following #270

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Solution` engine, solvent, database were not inherited by the sum of `Solution` objects (#258, @ugognw)
-- Bugs where incorrect $\alpha_1$ and $\alpha_2$ parameters were used to calculate activity
-  coefficients and solute molar volumes for salts with divalent (or greater) ions (#258, @ugognw)
-- calculation of salt concentrations in `Solution.get_salt_dict` for salts containing polyvalent cations (#258, @ugognw)
-- `Solution.get_salt_dict` now respects the `cutoff` parameter (#258, @ugognw)
-  - Note that `cutoff` is interpreted in units of moles per kilogram of solution (#258, @ugognw)
+- `Solution.__add__`: engine, solvent, database were not inherited by the sum of `Solution`
+  objects (#258, @ugognw)
+- `Solution.get_activity_coefficient`: Fixed bugs where incorrect Pitzer scaling parameters $\alpha_1$
+  and $\alpha_2$ parameters were used to calculate activity coefficients and solute molar volumes for salts with multivalent ions (#258, @ugognw)
+- `Solution.get_salt_dict`: fixed errors in the calculation of concentrations for salts
+  containing polyvalent cations (#258, @ugognw)
+- `Solution.get_salt_dict` now respects the `cutoff` parameter. Note that `cutoff`
+  is now interpreted in units of moles per kilogram of solution (#258, @ugognw)
 - `Solution.get_salt_dict` always returns a salt dictionary sorted in order of decreasing salt concentration (#258, @ugognw)
 - `Solution.__init__`: Raise `ValueError` if a user sets inconsistent `H[+1]` in `solutes` and
   `pH` keyword arguments (#270, @gnuhpdiem, @rkingsbury). Previously, if the user set `H[+1]` in `solutes`, it's value would silently override the `pH` kwarg. Now, you will get a `ValueError`

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -1523,7 +1523,7 @@ class Solution(MSONable):
             return None
 
     # TODO - modify? deprecate? make a salts property?
-    def get_salt_dict(self, cutoff: float = 1e-3, use_totals: bool = True) -> dict[str, dict[str, float | Salt]]:
+    def get_salt_dict(self, cutoff: float = 1e-6, use_totals: bool = True) -> dict[str, dict[str, float | Salt]]:
         """
         Returns a dict that represents the salts of the Solution by pairing anions and cations.
 
@@ -1534,7 +1534,7 @@ class Solution(MSONable):
 
         Args:
             cutoff: Lowest molal concentration to consider. No salts below this value will be included in the output.
-                Useful for excluding analysis of trace anions. Defaults to 1e-3.
+                Useful for excluding analysis of trace anions. Defaults to 1e-6 (1 part per million).
             use_totals: Whether or not to base the analysis on the concentration of the predominant species of each
                 element. Note that species in which a given element assumes a different oxidation state are always
                 treated separately.
@@ -1634,6 +1634,8 @@ class Solution(MSONable):
         cation_list = [[k, v] for k, v in cation_equiv.items()]
         anion_list = [[k, v] for k, v in anion_equiv.items()]
         solvent_mass = self.solvent_mass.to("kg").m
+        # tolerance for detecting edge cases where equilibrate() slightly changes the
+        # total amount of a solute
         _atol = 1e-16
 
         while index_cat < len_cat and index_an < len_an:

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -2572,11 +2572,9 @@ class Solution(MSONable):
             "this property is planned for a future release."
         )
         # calculate the new pH and pE (before reactions) by mixing
-        mix_pH = -np.log10(mix_amounts["H+"] / mix_vol.to("L").magnitude)
-
-        # now remove H+ and OH- from mix_amounts to avoid double setting pH
-        mix_amounts.pop("H[+1]", None)
-        mix_amounts.pop("OH[-1]", None)
+        # for pH, we make sure to conserve the mass of H+ and OH-. By not passing
+        # a kwarg for pH (i.e., by using the default value), the H+ concentration
+        # will override and determine the pH value of the mixed solution.
 
         # pE = -log[e-], so calculate the moles of e- in each solution and mix them
         mol_e_self = 10 ** (-1 * self.pE) * self.volume.to("L").magnitude
@@ -2590,7 +2588,7 @@ class Solution(MSONable):
             volume=str(mix_vol),
             pressure=str(mix_pressure),
             temperature=str(mix_temperature.to("K")),
-            pH=mix_pH,
+            # pH=7, # leave at default value so that H+ concentration determines pH
             pE=mix_pE,
             engine=self._engine,
             solvent=self.solvent,

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -668,7 +668,7 @@ class TestUnitActivity:
         assert all(activity_coefficients_unity)
 
     @staticmethod
-    @pytest.mark.parametrize(("salt_conc_units", "salt_conc", "engine"), [("mol/kg", 1e-4, "native")])
+    @pytest.mark.parametrize(("salt_conc_units", "salt_conc", "engine"), [("mol/kg", 1e-7, "native")])
     def test_should_return_unit_activity_for_all_solutes_when_salt_concentration_below_cutoff(
         solution: Solution, salt_conc_units: str, salt_conc: float, engine: str
     ) -> None:
@@ -682,7 +682,7 @@ class TestUnitActivity:
 
     @staticmethod
     @pytest.mark.parametrize("salt_conc_units", ["mol/kg"])
-    @pytest.mark.parametrize("salt_conc", [1e-4])
+    @pytest.mark.parametrize("salt_conc", [1e-7])
     @pytest.mark.parametrize("engine", ["native"])
     def test_should_log_error_when_no_salt_found_for_native_eos(
         solution: Solution, caplog: pytest.LogCaptureFixture

--- a/tests/test_osmotic_coeff.py
+++ b/tests/test_osmotic_coeff.py
@@ -149,7 +149,7 @@ class Test_osmotic_pitzer:
             assert np.isclose(result, expected, rtol=0.05)
 
     @staticmethod
-    @pytest.mark.parametrize(("salt_conc", "salt_conc_units"), [(1e-4, "mol/kg")])
+    @pytest.mark.parametrize(("salt_conc", "salt_conc_units"), [(1e-7, "mol/kg")])
     def test_should_return_unity_for_low_concentration_solutes(solution: Solution) -> None:
         assert solution.get_osmotic_coefficient().m == 1.0
 

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -905,7 +905,7 @@ class TestZeroSoluteVolume:
 
 class TestLinearCombinationSoluteVolume:
     @staticmethod
-    @pytest.mark.parametrize(("salt_conc", "salt_conc_units"), [(1e-4, "mol/kg")])
+    @pytest.mark.parametrize(("salt_conc", "salt_conc_units"), [(1e-7, "mol/kg")])
     def test_should_return_solute_volume_equal_to_linear_combination_of_molar_solute_volumes_for_dilute_solutions(
         solution: Solution,
     ) -> None:


### PR DESCRIPTION
#270 introduced a change to `Solution.__add__` that inadvertently broke mass conservation of H+ and OH- species when adding solutions. This PR fixes that issue. In brief, `__add__` now relies on conservation of mass of H+ and OH- in the `components` attribute to determine the new pH of the mixed solution.