### PR TITLE
Fix behavior of PHREEQC equilibrate when composition contains pure elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the valence (float, or "unk" for unknown) as the key at the second level. This should make it easier for future
   code to calculate the total amount of a given element regardless of its valence. (#284, @vineetbansal)
 
+### Fixed
+
+- `NativeEOS` `equilibrate`: We check if the total amount for any element decreases (within a tolerance of 1e-16 moles)
+  after speciation. If so, we add all species containing that element back in (unless they have been added by Phreeqc
+  already). As a result, we replace neutral (aq) molecules, and ions with incorrect charge, with ions with charge
+  determined by phreeqc, without double-counting. Missing elements (e.g. Rh) are handled correctly as well, since species
+  with the missing element are re-introduced in the solution. (#282, @vineetbansal)
+
 ## [1.3.2] - 2025-09-15
 
 ### Fixed

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -690,9 +690,10 @@ class NativeEOS(EOS):
         # by PHREEQC.
         _atol = 1e-16
 
+        new_el_dict = solution.get_el_amt_dict(nested=True)
         for el in orig_el_dict:
             orig_el_amount = sum([orig_el_dict[el][k] for k in orig_el_dict[el]])
-            new_el_amount = solution.get_total_amount(el, units="mol").magnitude
+            new_el_amount = sum([new_el_dict[el][k] for k in new_el_dict.get(el, [])])
 
             # If this element went "missing", add back all components that
             # contain this element (for any valence value)

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -1009,6 +1009,7 @@ class TestSolutionAdd:
         solution = Solution({"ReO4-2": "0.001 mg/L"}, balance_charge="auto", engine=engine)
         assert "ReO4[-2]" in solution.components
         assert "ReO4[-1]" not in solution.components
+        orig_el_amount = solution.get_total_amount("Re", "mol")
 
         with caplog.at_level(logging.INFO, "pyEQL"):
             solution.equilibrate()
@@ -1018,6 +1019,9 @@ class TestSolutionAdd:
         assert "amounts of species ['ReO4[-2]'] were not modified by PHREEQC" in caplog.text
         assert "ReO4[-1]" in solution.components
         assert "ReO4[-2]" not in solution.components
+        new_el_amount = solution.get_total_amount("Re", "mol")
+
+        assert np.isclose(new_el_amount, orig_el_amount)
 
     @staticmethod
     @pytest.mark.parametrize("engine", ["native"])
@@ -1027,6 +1031,7 @@ class TestSolutionAdd:
         solution = Solution({"Rh+3": "0.001 mg/L", "Rh2O3": "0.001 mg/L"}, balance_charge="auto", engine=engine)
         assert "Rh[+3]" in solution.components
         assert "Rh2O3(aq)" in solution.components
+        orig_el_amount = solution.get_total_amount("Rh", "mol")
 
         with caplog.at_level(logging.INFO, "pyEQL"):
             solution.equilibrate()
@@ -1037,6 +1042,9 @@ class TestSolutionAdd:
         )
         assert "Rh[+3]" in solution.components  # still there
         assert "Rh2O3(aq)" in solution.components  # still there
+        new_el_amount = solution.get_total_amount("Rh", "mol")
+
+        assert np.isclose(new_el_amount, orig_el_amount)
 
 
 class TestZeroSoluteVolume:


### PR DESCRIPTION
## Summary

Major changes:

- Issue #229:
  - Added 3 tests as per our discussion there (2 failing, 1 passing).
  - Code changes that fix the behavior, hopefully correctly.
  - Removed `xfails` to show that the introduced tests do pass with the change.
 
The `atol` I chose is totally arbitrary and I'm not sure if it's realistic. Happy to discuss more and introduce changes to this PR!

Some other unrelated minor changes seem to have been made by my `pre-commit` hook.

## Checklist

- [x] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.
<!-- - [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) -->

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
