### PR TITLE
Fix incorrect reduction of dimers/polymers in standardize_formula

### DIFF
--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -737,6 +737,16 @@ class NativeEOS(EOS):
         for s, mol in self.ppsol.species_moles.items():
             solution.components[s] = mol
 
+        # --- Code to demonstrate bug ---
+        # The standardized formula for (CO2)2 is still CO2, so this amount
+        # (negligible) ends up overwriting the original CO2 amount.
+        # We simply get lucky in the loop above that (CO2)2 is encountered
+        # before CO2 in the old wrapper, but we force surfacing the bug here.
+        problematic_keys = ("(CO2)2",)
+        for k in problematic_keys:
+            if k in self.ppsol.species_moles:
+                solution.components[k] = self.ppsol.species_moles[k]
+
         # log a message if any components were not touched by PHREEQC
         # if that was the case, re-adjust the charge balance to account for those species (since PHREEQC did not)
         missing_species = set(self._stored_comp.keys()) - {standardize_formula(s) for s in self.ppsol.species}

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -737,16 +737,6 @@ class NativeEOS(EOS):
         for s, mol in self.ppsol.species_moles.items():
             solution.components[s] = mol
 
-        # --- Code to demonstrate bug ---
-        # The standardized formula for (CO2)2 is still CO2, so this amount
-        # (negligible) ends up overwriting the original CO2 amount.
-        # We simply get lucky in the loop above that (CO2)2 is encountered
-        # before CO2 in the old wrapper, but we force surfacing the bug here.
-        problematic_keys = ("(CO2)2",)
-        for k in problematic_keys:
-            if k in self.ppsol.species_moles:
-                solution.components[k] = self.ppsol.species_moles[k]
-
         # log a message if any components were not touched by PHREEQC
         # if that was the case, re-adjust the charge balance to account for those species (since PHREEQC did not)
         missing_species = set(self._stored_comp.keys()) - {standardize_formula(s) for s in self.ppsol.species}

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -7,6 +7,7 @@ pyEQL utilities
 """
 
 import logging
+import re
 from collections import UserDict
 from functools import lru_cache
 from typing import Any
@@ -75,6 +76,12 @@ def standardize_formula(formula: str):
     # replace different types of dashes with a minus sign
     for char in [r"‑", r"‐", r"‒", r"–", r"—", r"−"]:  # noqa: RUF001
         formula = formula.replace(char, "-")
+
+    # Do not modify any dimers etc (Phreeqc reports a small amount of
+    # "(CO2)2" in a water solution with C(4), for example.
+    _POLYMER_RE = re.compile(r"^\([A-Za-z0-9+-]+\)\d+$")
+    if _POLYMER_RE.match(formula):
+        return formula
 
     sform = Ion.from_formula(formula).reduced_formula
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,6 +62,10 @@ def test_standardize_formula():
     assert standardize_formula("(NH4)2SO4") == "(NH4)2SO4(aq)"
     assert standardize_formula("NH4SO4-") == "NH4SO4[-1]"
 
+    # Polymers should be left intact
+    assert standardize_formula("(CO2)2") == "(CO2)2"
+    assert standardize_formula("(H2O)3") == "(H2O)3"
+
 
 def test_formula_dict():
     """


### PR DESCRIPTION
This is most likely a bug that we haven't encountered yet, simply because we're getting lucky in the order of the keys (representing species->amount mapping) in the current wrapper.

The tests that should fail in this PR is `test_phreeqc.py::test_equilibrate_logC_pH_carbonate_8_3` (among others).

The issue seems to be that for a simple solution like this:
```
Solution({"CO2(aq)": "0.001 mol/L"}, pH=8.3, volume="1 L", engine="phreeqc")
```
corresponding to the string:
```
SOLUTION 0
  temp 25.0
  units mol/kgw
  pH 8.3
  pe 8.5
  redox pe
  water 0.9970480319717386
  C(4) 0.0010029607079434515
SAVE SOLUTION 0
END
```
In addition to `CO2`, `phreeqc` reports a tiny amount of `(CO2)2` (whatever that represents, not sure..). The following is the output from phreeqc UI, and is consistent with what the old (and our new) wrappers return.
```
----------------------------Distribution of species----------------------------

                                               Log       Log       Log    mole V
   Species          Molality    Activity  Molality  Activity     Gamma   cm3/mol

   OH-             2.072e-06   2.019e-06    -5.684    -5.695    -0.011     -4.12
   H+              5.138e-09   5.012e-09    -8.289    -8.300    -0.011      0.00
   H2O             5.551e+01   1.000e+00     1.744    -0.000     0.000     18.07
C(4)          1.003e-03
   HCO3-           9.822e-04   9.575e-04    -3.008    -3.019    -0.011     24.57
   CO2             1.079e-05   1.079e-05    -4.967    -4.967     0.000     34.43
   CO3-2           9.923e-06   8.959e-06    -5.003    -5.048    -0.044     -3.97
   (CO2)2          2.137e-12   2.137e-12   -11.670   -11.670     0.000     68.87
H(0)          3.556e-37
   H2              1.778e-37   1.778e-37   -36.750   -36.750     0.000     28.61
O(0)          2.636e-19
   O2              1.318e-19   1.318e-19   -18.880   -18.880     0.000     30.40

------------------------------Saturation indices-------------------------------
```

The `standardize_formula` function standardizes `(CO2)2` as `CO2`, and can possibly end up overwriting the `CO2` amount with the `(CO2)2` amount (which is tiny), in the following logic in `.equilibrate()`:
```
        solution.components = FormulaDict({})
        # use the output from PHREEQC to update the Solution composition
        # the .species_moles attribute should return MOLES (not moles per ___)
        for s, mol in self.ppsol.species_moles.items():
            solution.components[s] = mol
```

We simply get lucky that `(CO2)2` is consistenly reported *before* `CO2` by the current wrapper, so we end up with the correct amount of `CO2`. In the new wrappers, the order of the keys in the dict is reversed (for whatever reason, but most probably because we're building the dictionary in the same order as the output of phreeqc UI indicates), so we do encounter this bug.

The attached snippet simply surfaces the bug without fixing it. I'm not sure of a solution without the background on what it means/entails.