### PR TITLE
Watching for Phreeqc invocation errors

### DIFF
--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -32,6 +32,26 @@ if TYPE_CHECKING:
     from pyEQL import solution
 
 
+"""
+We determine if PhreeqPython from the phreeqpython package is actually
+invocable on this platform, regardless of whether it is installed.
+This flag helps us selectively skip phreeqpython-related tests inside
+manylinux containers, among other uses.
+"""
+
+
+def _phreeqpython_available():
+    try:
+        PhreeqPython()
+    except:  # noqa: E722
+        return False
+    else:
+        return True
+
+
+PHREEQPYTHON_AVAILABLE = _phreeqpython_available()
+
+
 class EOS(ABC):
     """
     Abstract base class for pyEQL equation of state classes.

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -12,7 +12,6 @@ by USGS(PHREEQC)
 """
 
 import logging
-import platform
 from itertools import product
 
 import numpy as np
@@ -23,6 +22,7 @@ import pyEQL
 import pyEQL.activity_correction as ac
 from pyEQL import engines, ureg
 from pyEQL.activity_correction import _debye_parameter_activity, _debye_parameter_B
+from pyEQL.engines import PHREEQPYTHON_AVAILABLE
 from pyEQL.salt_ion_match import Salt
 from pyEQL.solution import Solution
 
@@ -289,7 +289,7 @@ def test_activity_crc_rbcl():
         assert np.isclose(result, expected, rtol=0.05)
 
 
-@pytest.mark.skipif(platform.machine() == "arm64" and platform.system() == "Darwin", reason="arm64 not supported")
+@pytest.mark.skipif(not PHREEQPYTHON_AVAILABLE, reason="Phreeqpython not available")
 def test_activity_crc_MgCl2():
     """
     calculate the activity coefficient of MgCl2 at each concentration and compare

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -3,12 +3,11 @@ Tests of pyEQL.functions module
 
 """
 
-import platform
-
 import numpy as np
 import pytest
 
 from pyEQL import Solution
+from pyEQL.engines import PHREEQPYTHON_AVAILABLE
 from pyEQL.functions import entropy_mix, gibbs_mix
 
 
@@ -42,7 +41,7 @@ def s2_i():
     return Solution({"Na+": "1 mol/L", "Cl-": "1 mol/L"}, volume="10 L", engine="ideal")
 
 
-@pytest.mark.skipif(platform.machine() == "arm64" and platform.system() == "Darwin", reason="arm64 not supported")
+@pytest.mark.skipif(not PHREEQPYTHON_AVAILABLE, reason="Phreeqpython not available")
 def test_mixing_functions(s1, s2, s1_p, s2_p, s1_i, s2_i):
     # mixing energy and entropy of any solution with itself should be zero
     assert np.isclose(gibbs_mix(s1, s1).magnitude, 0)

--- a/tests/test_phreeqc.py
+++ b/tests/test_phreeqc.py
@@ -7,16 +7,18 @@ used by pyEQL's Solution class
 """
 
 import logging
-import platform
 
 import numpy as np
 import pytest
 
 from pyEQL import Solution
-from pyEQL.engines import PhreeqcEOS
+from pyEQL.engines import PHREEQPYTHON_AVAILABLE, PhreeqcEOS
 
-if platform.machine().startswith("arm64") and platform.system().startswith("Darwin"):
-    pytest.skip("skipping PHREEQC tests because arm64 is not supported", allow_module_level=True)
+if not PHREEQPYTHON_AVAILABLE:
+    pytest.skip(
+        "Phreeqpython not available",
+        allow_module_level=True,
+    )
 
 
 @pytest.fixture

--- a/tests/test_salt_matching.py
+++ b/tests/test_salt_matching.py
@@ -7,13 +7,13 @@ salt_ion_match.py
 """
 
 import logging
-import platform
 from itertools import combinations, product
 
 import numpy as np
 import pytest
 
 import pyEQL
+from pyEQL.engines import PHREEQPYTHON_AVAILABLE
 from pyEQL.salt_ion_match import Salt
 
 _ANIONS = ["Cl[-1]", "SO4[-2]", "PO4[-3]", "ClO[-1]", "NO3[-1]", "CO3[-2]", "MnO4[-2]"]
@@ -147,7 +147,7 @@ def test_single_ion() -> None:
     assert s1.get_salt().nu_anion == 3
 
 
-@pytest.mark.skipif(platform.machine() == "arm64" and platform.system() == "Darwin", reason="arm64 not supported")
+@pytest.mark.skipif(not PHREEQPYTHON_AVAILABLE, reason="Phreeqpython not available")
 def test_salt_with_equilibration() -> None:
     """
     test matching a solution containing a salt, before and after equilibration.

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -8,7 +8,6 @@ used by pyEQL's Solution class
 
 import copy
 import logging
-import platform
 from importlib.resources import files
 from itertools import zip_longest
 
@@ -21,7 +20,7 @@ from pint import Quantity
 import pyEQL
 import pyEQL.activity_correction as ac
 from pyEQL import Solution, engines, ureg
-from pyEQL.engines import IdealEOS, NativeEOS
+from pyEQL.engines import PHREEQPYTHON_AVAILABLE, IdealEOS, NativeEOS
 from pyEQL.salt_ion_match import Salt
 from pyEQL.solution import UNKNOWN_OXI_STATE
 
@@ -123,7 +122,7 @@ def test_empty_solution():
     assert np.isclose(s1.viscosity_dynamic, s1.viscosity_kinematic * s1.density, atol=1e-8)
 
 
-@pytest.mark.skipif(platform.machine() == "arm64" and platform.system() == "Darwin", reason="arm64 not supported")
+@pytest.mark.skipif(not PHREEQPYTHON_AVAILABLE, reason="Phreeqpython not available")
 def test_oxi_state_handling():
     # see https://github.com/KingsburyLab/pyEQL/issues/116
     # and https://github.com/materialsproject/pymatgen/issues/3687
@@ -264,7 +263,7 @@ def test_chempot_energy(s1, s2):
     pass
 
 
-@pytest.mark.skipif(platform.machine() == "arm64" and platform.system() == "Darwin", reason="arm64 not supported")
+@pytest.mark.skipif(not PHREEQPYTHON_AVAILABLE, reason="Phreeqpython not available")
 def test_charge_balance(s3, s5, s5_pH, s6, s6_Ca):
     assert np.isclose(s3.charge_balance, 0)
     assert np.isclose(s5.charge_balance, 0, atol=1e-5)
@@ -475,8 +474,9 @@ def test_components_by_element(s1, s2):
         "Na(1.0)": ["Na[+1]"],
         "Cl(-1.0)": ["Cl[-1]"],
     }
-    if platform.machine() == "arm64" and platform.system() == "Darwin":
-        pytest.skip(reason="arm64 not supported")
+    if not PHREEQPYTHON_AVAILABLE:
+        pytest.skip(reason="Phreeqpython not available")
+
     s2.equilibrate()
     assert s2.get_components_by_element() == {
         "H(1.0)": ["H2O(aq)", "OH[-1]", "H[+1]", "HCl(aq)", "NaOH(aq)", "HClO(aq)", "HClO2(aq)"],
@@ -527,8 +527,8 @@ def test_components_by_element_nested(s1, s2):
         },
     }
 
-    if platform.machine() == "arm64" and platform.system() == "Darwin":
-        pytest.skip(reason="arm64 not supported")
+    if not PHREEQPYTHON_AVAILABLE:
+        pytest.skip(reason="Phreeqpython not available")
 
     s2.equilibrate()
 
@@ -583,7 +583,7 @@ def test_get_total_amount(s2):
     assert np.isclose(sox.get_total_amount("Fe", "mol").magnitude, 0.05)
 
 
-@pytest.mark.skipif(platform.machine() == "arm64" and platform.system() == "Darwin", reason="arm64 not supported")
+@pytest.mark.skipif(not PHREEQPYTHON_AVAILABLE, reason="Phreeqpython not available")
 def test_equilibrate(s1, s2, s5_pH):
     assert "H2(aq)" not in s1.components
     orig_pH = s1.pH
@@ -686,7 +686,7 @@ def test_conductivity(s1, s2):
     assert np.isclose(s_kcl.conductivity.magnitude, 10.862, atol=0.45)
 
 
-@pytest.mark.skipif(platform.machine() == "arm64" and platform.system() == "Darwin", reason="arm64 not supported")
+@pytest.mark.skipif(not PHREEQPYTHON_AVAILABLE, reason="Phreeqpython not available")
 def test_arithmetic_and_copy(s2, s6):
     s6_scale = copy.deepcopy(s6)
     s6_scale *= 1.5
@@ -981,7 +981,7 @@ class TestSolutionAdd:
 
     @staticmethod
     @pytest.mark.parametrize("engine", ["native"])
-    @pytest.mark.skipif(platform.machine() == "arm64" and platform.system() == "Darwin", reason="arm64 not supported")
+    @pytest.mark.skipif(not PHREEQPYTHON_AVAILABLE, reason="Phreeqpython not available")
     def test_should_replace_monatomic_species_from_engine(engine, caplog) -> None:
         # When initializing a solution without specifying the charge on the ion,
         # `.equilibrate()` should replace the ion with the ion with the charge
@@ -1003,7 +1003,7 @@ class TestSolutionAdd:
 
     @staticmethod
     @pytest.mark.parametrize("engine", ["native"])
-    @pytest.mark.skipif(platform.machine() == "arm64" and platform.system() == "Darwin", reason="arm64 not supported")
+    @pytest.mark.skipif(not PHREEQPYTHON_AVAILABLE, reason="Phreeqpython not available")
     def test_should_replace_diatomic_species_from_engine(engine, caplog) -> None:
         # When initializing a solution by specifying the charge on the ion
         # that is different from the one determined by phreeqc,
@@ -1028,7 +1028,7 @@ class TestSolutionAdd:
 
     @staticmethod
     @pytest.mark.parametrize("engine", ["native"])
-    @pytest.mark.skipif(platform.machine() == "arm64" and platform.system() == "Darwin", reason="arm64 not supported")
+    @pytest.mark.skipif(not PHREEQPYTHON_AVAILABLE, reason="Phreeqpython not available")
     def test_should_not_discard_missing_species_from_engine(engine, caplog) -> None:
         # When initializing a solution by specifying a species with an element
         # that is not found in phreeqc, the species should not be discarded.


### PR DESCRIPTION
## Summary

While testing `pyEQL` *inside* a `manylinux` container (this is something that [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/) supports and recommends, for example) to ensure that our C++ wrappers are not inadvertently relying on system-level libraries like `GLIBC` (making them not usable on future/obscure architectures), I discovered that `phreeqpython` is **NOT** really adhering to this standard. I.e., inside a minimal linux container that supports python and all other `pyEQL` dependencies, everything works except `phreeqpython`. This is not surprising since they never actually release platform-specific wheels, but [just their](https://pypi.org/project/phreeqpython/1.5.7/#files) `.tar.gz` and the platform-independent `*-none-any.whl`.

This means that we cannot run `pytest` inside these containers (which I think we should absolutely do), without skipping tests that pertain to `phreeqpython`.

This PR does this by adding a `PHREEQPYTHON_AVAILABLE` flag inside our code, much like our own `pyEQL.phreeqc.IS_AVAILABLE`, which checks to see if `phreeqpython` is actually usable, not just installed (the absence of binary wheels makes `phreeqpython` installable but not usable on many platforms). This is a good change anyway, since it allows us to do away with `if platform()=="Darwin"` kinda checks, where what we really needed to check is if `phreeqpython` is available.

I'm sending this PR now because it will surely be needed for a soon-to-come PR on `pyEQL` wheel-building anyway.

## Checklist

- [x] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.
<!-- - [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) -->

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
