### PR TITLE
updating basic tools before twine upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,5 +90,5 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.pypi_password }}
         run: |
-          python -m pip install --upgrade twine
+          python -m pip install --upgrade pip setuptools wheel packaging twine
           twine upload dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.0rc6] - 2026-02-05
+## [1.4.0rc9] - 2026-02-05
 
 ### Added
 

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -1,6 +1,6 @@
 [tool.cibuildwheel]
 build = "cp3*"
-skip = ["cp36-*", "cp37-*", "cp38-", "cp39-", "cp314*", "*-win32", "*-manylinux_i686", "*-musllinux_*"]
+skip = ["cp314*", "*-win32", "*-manylinux_i686", "*-musllinux_*"]
 build-verbosity = 1
 test-extras = ["testing"]
 # 01/24/26 - The latest version of scipy, 1.17.0, cannot be built on


### PR DESCRIPTION
Updating basic packaging tools (especially `packaging`) before attempting `twine` upload, as per [https://github.com/pypa/twine/issues/1216](https://github.com/pypa/twine/issues/1216).

This is working on a fork (after I changed the PyPI package name to try it out).

Also removed several old python versions that are no longer supported by latest cibuildwheel.