### PR TITLE
phreeqc2026 engine: ensure unit osmotic coefficient; refactor tests

### DIFF
--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -1021,7 +1021,14 @@ class Phreeqc2026EOS(EOS):
         return ureg.Quantity(act, "dimensionless")
 
     def get_osmotic_coefficient(self, solution: "solution.Solution") -> ureg.Quantity:
+        if self.ppsol is not None:
+            self.ppsol.forget()
+        self._setup_ppsol(solution)
+
         osmotic = self.ppsol.get_osmotic_coefficient()
+        if osmotic == 0:
+            # PHREEQC returns 0 when it assumes a unit osmotic coefficient, so we need to catch that case and return 1 instead.
+            osmotic = 1
         return ureg.Quantity(osmotic, "dimensionless")
 
     def get_solute_volume(self, solution: "solution.Solution") -> ureg.Quantity:


### PR DESCRIPTION
## Summary

This  PR ensures that the `phreeqc2026` engine returns a unit osmotic coefficient, unless PHREEQC itself returns a value other than zero. This is necessary to ensure that osmotic pressure calculations work as intended.

It also contains a bugfix where, if a user tries to use `get_osmotic_coefficient` without having first run `equilibrate`, there would be an error because the `ppsol` attribute has not been initialized.

Finally, unit test files are renamed and a new unit test added for both `phreeqc` and `phreeqc2026` engines.