### PR TITLE
utils: ensure python floats in FormulaDict

### DIFF
--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -224,7 +224,9 @@ class FormulaDict(UserDict):
         return super().__getitem__(standardize_formula(key))
 
     def __setitem__(self, key, value) -> None:
-        super().__setitem__(standardize_formula(key), value)
+        # ensure that all values are stored as python floats, not numpy types
+        # see https://numpy.org/doc/stable/release/2.0.0-notes.html#representation-of-numpy-scalars-changed
+        super().__setitem__(standardize_formula(key), float(value))
         # sort contents anytime an item is set
         self.data = dict(sorted(self.items(), key=lambda x: x[1], reverse=True))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ Tests of pyEQL.utils module
 
 """
 
+import numpy as np
 from iapws import IAPWS95, IAPWS97
 from pytest import raises
 
@@ -78,7 +79,7 @@ def test_formula_dict():
     del d["Mg+2"]
     assert "Mg[+2]" not in d
     assert not d.get("Mg[++]")
-    d.update({"Cl-": 0.5})
+    d.update({"Cl-": np.float64(0.5)})
     print(d, d.data)
     assert d["Cl[-1]"] == 0.5
     assert d.get("Na+") == 0.5


### PR DESCRIPTION
## Summary

This PR ensures that all amounts stored in `FormulaDict` (which is used by `Solution.components` are python `float`, not numpy `float`. 

As of numpy 2.0, the [representation of numpy floats](https://numpy.org/doc/stable/release/2.0.0-notes.html#representation-of-numpy-scalars-changed) has changed, and this causes some visual clutter and problems with tests that rely on string comparisons of amounts.