### PR TITLE
Docs: docstring improvements re equilibrate and charge balancing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,6 +176,7 @@ html_theme_options = {
     # "sidebar_width": "300px",
     # "page_width": "1200px",
     "site_url": "https://pyeql.readthedocs.io/en/latest/",
+    "site_name": "pyEQL documentation",
     "repo_url": "https://github.com/KingsburyLab/pyEQL/",
     "repo_name": "pyEQL",
     # 'logo_icon': 'e798',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,6 +180,12 @@ html_theme_options = {
     "repo_url": "https://github.com/KingsburyLab/pyEQL/",
     "repo_name": "pyEQL",
     # 'logo_icon': 'e798',
+    "nav_links": 
+    [{
+            "title": "Releases",
+            "url": "https://github.com/KingsburyLab/pyEQL/releases",
+            "internal": False,
+    },],
     "toc_title": "pyEQL: a python interface for water chemistry",
     "palette": { "primary": "blue", "accent": "light-blue" },
     "globaltoc_collapse": True,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,6 +10,10 @@ Virtually all of the user-facing functions in `pyEQL` are accessed through the
 
 ## Creating a Solution Object
 
+```{warning}
+By default, pyEQL does **not** perform charge balancing or chemical equilibrium.
+If required, explicitly call `Solution.adjust_charge_balance()` or `Solution.equilibrate()`.
+
 Create a Solution object by invoking the Solution class:
 
 ```{eval-rst}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,8 +11,9 @@ Virtually all of the user-facing functions in `pyEQL` are accessed through the
 ## Creating a Solution Object
 
 ```{warning}
-By default, pyEQL does **not** perform charge balancing or chemical equilibrium.
-If required, explicitly call `Solution.adjust_charge_balance()` or `Solution.equilibrate()`.
+By default, pyEQL does **not** perform charge balancing or chemical speciation.
+For automatic charge balancing, set the `balance_charge` keyword argument to a non-default value such as `auto`.
+For automatic speciation, set `auto_eq=True` or `call Solution.equilibrate()`.
 
 Create a Solution object by invoking the Solution class:
 

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -775,11 +775,11 @@ class Solution(MSONable):
     @property
     def charge_balance(self) -> float:
         r"""
-        Return the charge balance of the solution.
+        Return the signed charge balance of the solution, positive or negative.
 
-        Return the charge balance of the solution. The charge balance represents the net electric charge
-        on the solution and SHOULD equal zero at all times, but due to numerical errors will usually
-        have a small nonzero value. It is calculated according to:
+        Return the signed charge balance of the solution, positive or negative. The charge balance represents the net electric charge 
+        of the solution and SHOULD equal zero at all times, but due to numerical errors will usually have a small nonzero value. 
+        Positive values indicate excess cationic charge, while negative values indivate excess anionic charge. It is calculated according to:
 
         .. math:: CB = \sum_i C_i z_i
 
@@ -787,7 +787,7 @@ class Solution(MSONable):
 
         Returns:
             float :
-                The charge balance of the solution, in equivalents (mol of charge) per L.
+                The signed charge balance of the solution, in equivalents (mol of charge) per L.
 
         """
         charge_balance = 0
@@ -1708,6 +1708,10 @@ class Solution(MSONable):
                 are equivalent (log10(0.000316) = -3.5)
                 {"CO2": "0.000316 atm"}
                 {"CO2": -3.5}
+            **kwargs:
+                Additional engine-specific options passed to the underlying equilbrium
+                solver. These may include solver tolerances, or other advanced configuration
+                parameters introduced in v1.4.0.
         """
         if self.engine == "native":
             warnings.warn(

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -1708,14 +1708,6 @@ class Solution(MSONable):
                 are equivalent (log10(0.000316) = -3.5)
                 {"CO2": "0.000316 atm"}
                 {"CO2": -3.5}
-            engine options:
-                ideal: Ideal solution model
-                phreeqc: Uses phreeqpython with phreeqc.dat
-                phreeqc2026: Uses pyEQL.phreeqc with phreeqc.dat (v3.8)
-                native: Uses built-in Pitzer activity model (when available); falls back to other models if not
-            database options:
-                Default: phreeqc.dat
-                Additional: vitens.dat, wateq4f_PWN.dat, pitzer.dat, llnl.dat, geothermal.dat
             **kwargs:
                 Additional engine-specific options passed to the underlying equilbrium
                 solver. These may include solver tolerances, or other advanced configuration

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -1708,6 +1708,14 @@ class Solution(MSONable):
                 are equivalent (log10(0.000316) = -3.5)
                 {"CO2": "0.000316 atm"}
                 {"CO2": -3.5}
+            engine options:
+                ideal: Ideal solution model
+                phreeqc: Uses phreeqpython with phreeqc.dat
+                phreeqc2026: Uses pyEQL.phreeqc with phreeqc.dat (v3.8)
+                native: Uses built-in Pitzer activity model (when available); falls back to other models if not
+            database options:
+                Default: phreeqc.dat
+                Additional: vitens.dat, wateq4f_PWN.dat, pitzer.dat, llnl.dat, geothermal.dat
             **kwargs:
                 Additional engine-specific options passed to the underlying equilbrium
                 solver. These may include solver tolerances, or other advanced configuration

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -1693,13 +1693,16 @@ class Solution(MSONable):
 
         Keyword Args:
             atmosphere:
-                Boolean indicating whether to equilibrate the solution
-                w.r.t atmospheric gases.
+                Boolean indicating whether to equilibrate the solution w.r.t
+                atmospheric gases. By default, this considers equilibrium with
+                atmospheric CO2 (420 ppm) and O2 (0.21 atm). N2 is
+                typically not considered due to its low solubility and limited
+                impact on aqueous speciation.
             solids:
-                A list of solids used to achieve liquid-solid equilibrium. Each
-                solid in this list should be present in the Phreeqc database.
-                We assume a target saturation index of 0 and an infinite
-                amount of material.
+                A list of solids used to achieve liquid–solid equilibrium. Each
+                solid in this list should be the name of a mineral phase present
+                in the Phreeqc database (e.g. "Calcite"). We assume a target
+                saturation index of 0 and an infinite amount of material.
             gases:
                 A dictionary of gases used to achieve liquid-gas equilibrium.
                 Each key denotes the gas species, and the corresponding value


### PR DESCRIPTION
## Summary

Major changes: Updated the doc file for increased clarity, specifically:

- feature 1: updated the charge_balance docstring
- feature 2: updated the new kwargs added in v.1.4.0
- feature 3: added a warning box for solution initialization with regard to charge balancing and equilibration
- feature 4: removed the "src" from "pyEQL src documentation"
- feature 5: added a link to the GitHub releases
Advances #370 

## Checklist

- [ ] Google format doc strings added.
- [ ] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] I have run the tests locally and they passed.
<!-- - [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) -->

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
