### PR TITLE
New tutorial for solid-liquid-gas equilibrium

### DIFF
--- a/docs/examples/pyeql_tutorial_equilibrium.ipynb
+++ b/docs/examples/pyeql_tutorial_equilibrium.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "attachments": {
+    "b51ca3f4-e8bd-4b0a-a599-5f6724ad8fe5.png": {
+     "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZkAAABkCAYAAABU3k29AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAR5wAAEecBLFYGiAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAACAASURBVHic7Z13mBVF1sbf7q6qvmkGBhB0FUUxLuaEAVcQw2JAUQdXUdYIhjXrqru6ez/FtLrmBAYwKyMmTCgC5ohpxTVjQgVJAzd1VXX390fNrKMyt++d6b6xf8/TDz503apzx6FP16lz3qOhTGz77oqdNZcab20VeQma5pbLjl/guvrg99O7Oy4WvbVV4r1ymxMSEpKXAQC2B7AugP4A1gGwNoAEAANA46/GtwJw2v78FsDXbX9+CeDNtv8O8RmtHIsOefn7tXWNHGcAOhx7gUD0/pd36bmsHLa0M+L1zxqzMn6YBn1t6IbgDia+MmS178tpU0hNsgGAT8ttRDfZFcCLZVh3fQD7t62/PYB+Ps//A5SzmQ3gcQDzfZ6/q1wA4MI8998HsGWJbCmakjuZobPnR2K2c7rrar1011Hru8hprt3yxB83er/U9gDA/jM+728Df3Y19Gz/O1fTF67VtO41k7bVRDlsCqlZQidTHGsDGAdgFIDfl2jNdj4A8AiAWwEsKPHaHalqJ0NKveCGDUvspQsi8+E6a6i/caC5jqkBxzRPe2fmoAO3eiKpaU6p7Gl++N09tJUr9nUN6ADgaroLTbPh6q9M2iN0MCEhZWJHAKcBOBBleE61sXnb9TcALQCuBvB2mWypWsoSLgOAwx94YwvdkWNd10no7ca4rqZp7jfSJpPuHrvzoiDXb546jzXkFh/h6NpgAHDbzoVcV2vViDbxzj/t/EWQ64fULeFOJj+bALgewPCA5u8uTwA4Feocp1RU9U6mbE4GAI657ZleTMPxrutuoNmuBqBtO+FYgDvlxuP3ey2IdU++7qnVXNM52XG1dTRNc/+3bTL0/1qaddMdx+y/Moh1Q0IQOpnOMAD8FcD5AGI+z+03KaiH/r+hEgmCJnQy3aG5eaoxYGf9ABvOgZqraZrraIALHYDrui/naI/brj9lb8uv9c65aupmjuucomlIOAA0zWhzMs70b17Vpra0jLa95jhw2kdrZHqYo6xIbDE3G5bl4tqHc38f/8EvG0NqmtDJ/JY1ADwIYBcf5ywFLwI4BMCPAa9T1U7G11jn1nNXbhLjuX6xnNWH5dLLnhix0fNen2lpGW2jBdMuuGzyp5rEqZrmNgEO2nY2wxNaaqMJE2779/nnH/t1N83T/m/CpAPc1IoxgKu7Rnt4TLd06Lckzz+y4H80pptdTeawgauTdWwjJzTR8ANUZkpISEhxbAngUaj042rjDwBehUpKKEvSUjXgq5OJALuYtj2AihyjlrUAgKeTaeeic4/6z2XnTDxTM3JnusDWGhzAATS4A+G611xxzlVTzr78jMe6YlcymYzEcz1PdVOpP2hQ4TFX1wFgocvoxeclTywqvkq41cSIYTicEptSh2cyqa7YFRJS52wHYAaApi5+XgL4EOow/gMA30C97H0HIAtgZdsYAKBQ9TMxqJqa1aEy17YAsC1U5lpXnofrQqU874kwKWCV+OpkGM+2GrkcoZwbVFhF57Cfe/n4VgD/vP7UCaMBHAXXNdQZjcsA9+SbTr5wC9d2rjrppmTBD/Ubz5jQHz/JC6GvWAsAHE2DOodx34FjX3LK9ckVxdppilxPmxvENqhj5wwSb0yEZzghfjIIwEflNiJgtodyMD29Bv6KFVCH7w8DeBpApsDPCQDL2q5VpSMnAIyA2pXsC6ChCJuaADwHYC+oOpuQDujeQwqHCLmcSWFQkSMRIXoeOXl2pAvTuCdfe/6DZqb13Ghm5YpYJsWimZVm25+7J6zUxHuPPHuDQiaafOTZu8RbWyfFcumBscxKM5ZJs3g2TSPZldOWNtl/64qDAQDKeS8quEGtHGHSMpYbDV2aJySkThkA5SCKcTCfAPgLgDUBjAEwDYU7mEJIQaUpH9a2xikAPivi8z2hvtO6PtpUE/i7k8mmllNuESqEQXiORDJiNXRRqmHcrVe8N/mA044xo+ICHe7OutuuPOOuD7h3TPvT+BsOfGDiVA34jSRNMpnUN/3o+xOcXOoIwNUAzXU0DYCb1TRcfMh9N8/sxteEwXlvRghxdOI4nIq5YcFmSEihxKGq6XsVOH4hVNbZ3VjFv/WAWAmVRn0DgCMA/AuFqQv0gvpuOwBIB2ZdleGrk9G5XGpybjBuESa5EZXZvuiGHtBRj16z3AXOemL/sYdqcE91XZdpcKE5YC5w3lP7Hrrjczn5zz1mtrS2f+axkUc3GG9/egmg7QIdLqDBBeBo+nym6WeMeHTKV939nlTy3i4nhtQJYYSG5zEhIYVzLYDNChw7HcBRAJYEZ05eXAB3AXgKwBQA+xTwmU0BXAfgmODMqi58DZdFqbuEcItQzg3GuUGc3OrdnVMD3P0eu+u+WC5zdDSdWhhLp1ksmzLjmRSLZ1J7Uif3yPO77Lc1ALzwh303aFy5uCWeSQ+PZ1Msmk6Z0XSKxTKplxpbs2P9cDAAYFpWH0PkCJPcMHh46B8SUiC7obCHrwuVsnsAyudgOrIYwEgAF6Ow3dTRqNxi0pLj605m0Osty79bb1eXCW5QbhHKRbedTDu7zZg2b/bQoQdHcsbFuoZ9NNeF60LTXHcdwH3gzcHDZiOX2snVdFXIpWuuC81xoP17x9eem7SqsFpXmDhuIv1eip6SG9I1csQ2aHgeExLiTQTAxALGOQCOBTA5WHOKxoEqFJ0PpWXmVWN4C9SOLRewXRWPr04mmUw64297tpWKXAMTlkF59nd+zj9szpwUgFM/3Hzwiy7cS+EiqsEFHDRqmnuMq2kWgOUONAea1mrAPWXQB2/O8tOGFY0rmgzeQE1Ddx2DOlJPh04mJMSbv0CpKHtxDirPwXTkdqjzmYs9xq0PlTzwr8AtqnB8DZcBALWySxnnBuGcMM59dTLtbPrBG9MaMqlDYpmVP8bSKxsT2RWJWCalxVIrI9FMqjGeTi2IZNPNfjsYACDS6W0Ky6CWRZjgRkS6rd6fCgmpaxIAzitg3BQAVwZrii9cAuCeAsadi+JSoWsS351MRPKfCLeIKSyDcL5GMpn0fQ0AGPD5R+/GU0uHxrKpB6LptB1Lp7RYNuXE0ulH4uklwzf87MP/BrGuaVt9CLcIFZZBrRwxhFULToYBGAglF7I7gIMANLdd+7X93WYAzHIZGFLVHAnvbLLPoN78q4WTAXzlMaYJ6nymrvFdQlvP5Zb8vJOxaL9W9AEQiKLy6gsXpgGMT/fo9bbt2DdCx5UNra1/9+v8ZVWQXKYv03XDNgixDepYVnZ5UGsFhAlVCLcrgCFQzmMNFKZj50B1E/wQwBtQtQof+2DT9vCWFZmF8h8CH4T8L2ZZqELBkJ8hAM4sYNzpUKnD1cJyAGcBeMhj3BkAboIqBq1LfHcyVMhFVFiEcctgnBtcrFgTATmZduKtS291gae0EjQWMqXs4wiL2IQ4tmGQGJyydvQsEB2qGnk0VMZOsVXWHedZt+3aD8AEAC9DhQ+e7oZ9WwCY5DHmHJQ3vr09vB8o9yN0Mr9mb6jiy3zMAPBk8Kb4zjQo6ax8mWRrQykIPFISiyoQ/89kZHYRE9xgghtEWCQi7DX9XmNVlMLBAAARub6Uq+w5JqQOLFxainW7CIParv8XKtf/SHTdwXTGkLa534ZqjdsVWuCdhXNoF+f2izEFjLk7cCuqj+YCxuRTGK50LilgzOjArahgAjgvMX78+SHMDcpza/m/RvkwOe9nCrVLoyKXSSaT0vtTZWEwgHehsmE2LMF620Cp6c7swnrLoSql87ElSt9+tx0CJemej4VQ+lUhPxOH6myZj1fbrmplFryFMQ8A0FgCWyoS351MMjk+QwVPM6Eq/ykX/f1eo5xQYfUjnBMqLYNyXqnnMecBeAXleSgPh3JuRxX5uUJ2AeXazewOb1mR+/Gz4m+IYi94NyC7qRSGBIxX/U8ESnyzLgkk84tyaxHhOUKFZZjCqi0nY+XWMIXVtlOzKu08RoPSW7oEqtNguYgBuAOqJ3qhjfGegffZ3aFFzOcnYaisa+zhcT8NpaZc7bQA4B5jvH4WNUswTsayFpqCq1oSzgcEsUY5eHXH5igToifhFmEWN6jFK83JnAbgpHIb0YHTANxc4FgJtRvIx0CoMGApiUOFO/IxD8A7JbCl2hjqcf9ZqIy8aqcVKmyWj11LYUgl4nt2GQCY0vqBcK7OZESuz+yhQxNt1fpVTURb0peLGGGEONIgxKTG4nLb1IEtAFzehc8JKKmMjwF8AZVGuqLtTw0q178ngI2g1GWLlQoaD1VPcFkBY+8CcKrHmEMBvF6kDd1hf6hiwnyEu5jf0hfqdyYftZSJNx3AH/PcXx+qVKDuOugG4mSIlfuBCctQB/+cRNP22qiBJkxOKrO6mTAM2zAIMwzH4aSSdjL/gur+VwgLoNIvpwN4AcXl8K8HlTE0HoX3zrgYqpmT19veO1C7gkF5xhwCVXdRqvMPr1CZA+DeUhhSZewM79DmC6UwpEQU0r59CFRora4IJFxmOvb3jFsGFZxQzg0is9XYv/s3RKVcXdUAKefJhKyUncweUO1fvWiFkrpYH2rHMBPFF4l9CbVj2hDAiVDNnrzQofSoehQw9i6P+/1QOoXbvvD+uc6Gavcb8ks297j/A9TOuVaYB8CrnMHrZ1KTBONkUnyBcjCWQYVFiJQ10S3OdKzVVZGpKjbVMtlKcTKFhKLmQf2SXw5/lGEl1HnLVgBeK2D82ihMv+peALbHmFJlmY2G924/DJWtmo097r9REitKhwvvVOZNSmFIpRGIk9lrx/UXUs4dKizChGWY3KqJnYyRE2tQzg0qLINyTiJ29qdy2wRgJwBbe4x5G2qr/k0A638OYBcUFjI6GYCXaOoCeIfVRgGIFrBed/EKldVKdlQQ5At5AsD7JbGitLzncd/rZ1KTBOJktGTSodxayCwrSjnvwSxrvSDWaWMggHG/unoHsRDj2d9RbjVQkYua3MLwXmYl7GS8mkBloB6WQdb02AD+DO+CyhiURpUXXruDRiipjiBZH96ZbI+iuvS2SoUOYAOPMZ+XwpAS4/WdBqLwc9OawXcnM7W52Xh1xz1GUWFtTIW1GuVWnAm+hd/rdGAwVDFUxyuQ2hwm+AZMWAlmiT5U8n5vLGg95rndmws5ZwgKAm/ZjqsBfFoCW2yoAkyvdtvHwLtA72F4n/UEHTI7DN4H12GobNWsBlWAmI9S/E6Wmk887lOoDLO6wjcnM7X5xMSMEaOP7rco8xyxxb/VGz8HExxU8AFueYsDfYFyaxMmBKjkIEJQIqxzTZ5+6dk9D77k4VFjSyHd8msGwbtfhVftiZ8shbfibhO8HUQhYai94b8OW0e8QmU/QCVOhPwWL3UEQKXN1xqFfKdCfjY1RbdTmCeOG9ejaZl2cNRacRgRfHUqBKNC6EwIh3KuUW65lHMB9cP9vvsmlw8quSsFdwilGhXClZIbVLCooOIAU8gR0w457uVMNDH1iwE9Xkkmk04JTNrW4/5XUAf+pWQaVCuATfOMOQRKUy0fdwMYm+e+CSW97zVPV9gO3vpr98E7QaFe8XpblwAqIdTsNwuhEgDy7YB9a0lfLXTZyVx9WnJAj1RmTCSd2ZM6mTgTnFEpDSK5QSU3DMk5k2IOkfLKRGr5M5qqJ6hq4unUGstodCsmxFhB+IFEEIMQblBBHUkEIVzsRA1r2/7fpBfddMqF09Ms+vjZV54dZJuDtT3ue4WugsABcB3yS/cPA9AH+R80s6BSg/MJrB6GYJxMITIyhXRGrFe83tYXI8CeT2WEQ5UJ5Nthh07Giwl/v277RC4zKpZJb29IYVIhKBWWQQQ3COcGFUKjQswybHHzGt9/XcrK7JLQtPynd7Ec736x3npJwsloSsRYScTqgnKDCGYQKgzTFr1tbo2hunHwZX+/7q20GXn8on+Mexv+/8PySnAoV3XxVADXovMMMAIV7spXE9Ne5HhOnjFDobLV/NwhEwB/8hjzH3hnEtUzXr+XtbiLaecn5HcygSQlVTIFOZnm5qnG+tvlhkQzmZFmLr0xFYIZghMihEFsYVAhDCqlS6V4nIjsbRt9/F4grY8riYFfftkK4NYkcPs+2w7bkQgx2iDWUCqoIQk3CKEOpYxIwbcxKd3sb5fd+U02Fn/O6Nkw68qxe6V9MiPucb9culCtUE3M8sm8D4d34eVdyO9kdCiHcFVR1uVnOLzfxIM+8C91iDMfJ6F4pWSvNt2Vql7uB17t2L0SImqOvE6meeo8tvqyr4ea6ZX7kKxci9qSUiHUrkVygwmhU2FlDCkmw7anbvfm7EqoGykpScBJvj37FQCvvLDn/v1twQ80KN2HSRGTghuSUMMW1KCUrimFGJNN8/2OnTLr5SyJzbr38B1quVJ8BvI7mT2gYtf5dncfQRXt5UslPhz+Opl850CAOk+408f1ahGvB6mXYnE1Y3nc93LANccqncyYpz5rNFp/HB5t/W6YIXK9mBSMCaETYRlUcIMIbjAhlhCbP0Bz+uO7P/eIX2/mVc2uzz72LYBrpzY338y4OcQi1kGEso0MoXZ7wuAO4TxOKB1GKN159LS5X2RisZdSkY3fmjNMq7VeJLM97q8BYB2o5IR83If8TmYrqEN6P1Ji4wBGeoyZjYDbidcAXg/SWnYyXt+tvncye874vG+cW3s4K5cOjnAZpbZkhHPDEPx/YTEixTdM8pYVcf78ofdOLlb3qi4Y3dLCoQ6uZ0066bwNpSAjpKC7UEp1KbkhOTUkYYYkfF1TsDVt+tUew15d+MayKHvjva2aaiWU8BlUSnOvPGO2gLeTuQdK/DPfg+twAP8oxrhOGAVvxeUpPqxT63g5Ga+3/Wom3Mn8CgIAf3gz059mW3czs6nNiLRMagtKpDCItAwmZdvuxZprity08Tdd9GG5ja4mxt146acAPr3q9Kvu5lTsSQ2+myAsTiQ3iKS2wblBKO9JLDYsTiKDt/9v7oE3N4nUSqHaf6HUeDtjUwCPecyxFOp8J19Pl8MA/BPdT6zwyipbCVXlH5Ifr/q7Wswsa8crizYQlZVKhmw3d+Vo8MzmVFjMEJzQttAOFcIwLEvXBX8Xtnz87MvOrKTDyKrjjKvPWArgAdd1Hzz36ns3lRbZVVC2OaNStwU3JLEMIomRS6dr6ZzmI+R3Ml4iiu3ch/xOZiCAbeAtUJiP1eCt7vwolExPSH683uZZSawoD/W8i1slhMBpVW/VwqDSMogUOpFCEslfZNR4ZsKZR9fdYX6QaJrmQqXA/uf4m2f05SQ3xDDo9oQKxrLWx3N3WruWHmJegpxrFjjPY1Bpr33yjDkC3XMyh8FbV2pKN+avJ0In0zn152RM3XmDWtYwdZjPU9ThM2MNiVevPmbPWmiLWtHccsJeiwA8fOTk2U+5zNwWRAShklxOFnrcL7QwjUM1ezohz5g/oXvNzLxCZd8CmNPFueuNenYyXt+t/pzMnK2alu/z9KdvEsmX9kr0fu36vXeoux9CuZly1LAcgJfLbUcAeDmZYsQC70Z+J9MXwG5QfeOLZSMoKZl83IvSqVYcC+DrEq3lxcdd+IzXM8Srvqua8fpudfd8JQDw5IgNy90TQ0PXJW5WJbxJ0HVJbYnaPpgsJV6Zcj3gXSvTzutQnRQH5hkzGl1zMqMLGHNfF+btKq+hutuVe7Ul71sSK8qD13dbUhIrKohKyXQ4Diok0pVrVVXjb3VjvnwH1SHF4fXWpqHwlE4X3kWQzSi+mZkG1QsnH+9AnaOFFIZXHdFqJbGi9BjIn7IP1GGNVaU4mZDapJA2z8UUp92F/CGrRgD7FDEfAGyP/LsjIOwbUyxeD9IIvFtUVCNN8G5pUneJVKGTCQmSQop1iylO+xoqlJSPQkJfHfESw7QBPFjknPVOIW/rXgri1UghbeZDJxMS4iOFhK6KVY2Y7HF/JApvZkbhnVU2A+VTs65Wvod3rx2v9szViFcPIhfeaf01R7eblvnEl/DuhNgZ/fHbzKDn4a2G2hm1LENearwkWoDilaJboPrVdNbCuZhmZrvD+3wgDJUVjwXVJXL9PGM2KpEtpcTrO30L1fU1pMo4DOoNoeO1ZVkt6gLNU99Yd+TTH3uJM/6ayfjtd+94TfHTxi6wL/Lb5yB/F8HOuN9j3kLbIt/jMc8y+C9ouIHHmi6A3/u8Zjl4Evm/4x3lMy0wvH4vn+vivBd4zFvRvY0IADS/+m1ULE39fnn8x/fnDBtWa2rAFUtz81Sj54jegzOR2LBcJNZXGEQMnb3ooznD+n5ebtt8wutw10LX0sXvQ/6zlKFQPWHy1enE4K24/BgKS14I+S2fQDWm64x8ytrVyg4e9z8piRUVBgGAZY6xTYSQUX2WNf5p7D0vvh9b2Tr7lhP2W1Bu42qV6657ypzvpoZZkcTuGUYbbca4pIRLQm07SnYAUC9OpquhyacB/IjOFQMMqB3u1XnmGAVv+6YUbVlIO+973N8EKhvLq6amWlgDwACPMe+WwI6KgwCAgL4dIdS2aYRJJncSscSuf7l5+mexTPrF+a/rb7W0jPY6xAspgMv/enlDtqHXXt/z1j3saCwmKOPCoFwwZnODOpKZNmes36B5Lps3SKuFnhteHSa7KgYqoVo8n5JnzGjkdzJeWWXfAXixSLtCfuYVj/sagJ2gwmq1wE4FjHk1cCsqELLNJ24f2bq8p7RtR0hmE0ltKoghmLkxF2Lz9bfNLJmw6S0zzZUrZ5195dnhoVUXuOGkv69jxXo058zEjpIyh1PKBaFCMGbblNmSElsY9GtLY7Pf2Cr+ETStVPIlQeOVQdSdTJvJyO9kdkDnzcz6Afijx/xeNTkh+fkcKisvn3TQSNSOk9nf4/5P6JpET9VD5m6kLR46b9EVXNCtDUKHUGL2FVTYhhAGZdS2JelrSXYkYebRV59x6dtmNvPMiTdfNLfchlcD94w5dbtMIj4qS6PbSGoKQSmXhNmSUEcyZktiSsHoB1lde27m8HXml9veAPDKtulOW4P3oKRX8h2SjwYwYRV/fxC8MytLKSNTq7wOFZbsjH1RuKxQJUOQ//wJUG3Eq/17dgkCAHMG9U0BeBHJ5Mv77TBmEyHJMMbYpkJygxNmEyptzphhOGInJsTQ24895+toOv0EkQtnjG5pCdWaO+Amk/r097/cOxNJNOcibF2bMC4pE9KgtmTM5pTaklAuKH3F0s0Z00ZuXqtnXya8s/y6K9UyBaprZmf8Gat2Ml4yMm8DCPsndZ9nkN/J/A7Ajqj+MNJQAL09xjxRAjsqkl++zSWTznQk5wGYd8TD7/cVnO9CTDFcStIkKLOpsAxBmU2kWE8wfhaxm055cuRhsyKpzP3DZz36RXm+QmXw6o47Rnm0z8FPv/XJn0Q01lcSygUhnFPqSGraglJbELaCE/KsFmEzpxy+a60L5W0Jb9nz7u6I7wdwGTovKl4fwFb45YHrevBWXA53Mf7wMIAbkX/XeAqq38mc7HFfAphWCkMqkU7/59994BaLAEw7cvLsJykXOxlSjBDU3IAIqVNCbUmZbUsRFSJygGHazS/uuvfcaC77UCrqPjtszpy6SYP+fPPN+y6nPY/K0fgBnLAGQSgX1ORt4TBbUmoLnS6SEfMhrhuzbzjpgHrZ+XlpiK1E93cL30HVHuyVZ8zh+KWTGYv8tTkCqn4mpPsshmphMTTPmIOgCqq/LYVBATAQKuyXj5dRx0XenhX/bb1OZgGYdf5FEwcSSvaXgu0mqTCk4DanxCA2cQRlg4mQu/RoTS37ZOOtHoyvzE5Za8HHNfu2/u1a622Qi8VPSeuxETajkIRwSZiQKhxmC0JsTul8x4zeL8miFyf89cS6cbxt7Odxfy78OVi/D/mdTDOAszusdYjHfDNRh/pSAfIQ8jsZAuB0AGeUxBr/ORPe8lx1vTMuSlZmwgXjvwBw1aXnXjqZCLInp+xgIsVaUkhdUmFLym0pWR8hxWm5iHb6gt+t/Vwsk7mrafni2QHZX3JaG3vtYEXjp6UoHSYIldJgXBDGBWEqJEZN22b0JYeYU0+95u/voj4P+3aG93nMYz6t9RCAG9B5zUt/qIfcLCjF5Y095pvik10hijsBXAzVO6gz/gLgFqw6E7CS2QzAOI8xS1DnO+MuaZedd9l5ywA8OLU5+YgV57txRg8hNt2SUGYTIWxOqEGJ2UNQOUZQcXgq0eP7eKp1sKYK6KqWdCz+YY6QjTilsAm1BKVLJaO2pMTmlNk2pXMsatz959uvrMuiqw6cVsAYvw5CMwAeBXBEnjGjoZyMV23MCh/tClGkoNLB851bUKiztQNLYpE/aAAuh7e0/z0oXp+vpuiWQOboliSHyiB55skDj1lHUDmKEH4YobSPZFSnkhiSMo1LsWZKxeCrGs4iTZyZhqTU5cQ0JDFtQWhKEPaAo9G7D3zo9lrNFCuG7aHi7Pn4EP6qGtyN/E7mYKiQjJeTmQbltEL85QYAJyL/A3kU1K5gUkks6j4nAxjhMUYAuL4EtlQ0vqkw7/Pw7V8DuOa53ZsnG7ZoplxMMCiL60LCoKJ19RpQHxXUnCsZ24dTE8Kkrs3YjQ60O/d4dloYw1dEANwKb9HLG3xedxaABQDW7OR+b6i3znyFgUCouBwUn0IVzx7rMe4aqPTxdwK3qHsMRv7U+XZug2oZXtf43k9mj5ktrUNeee42ycy5grIlkrKcYGZNaHFxZn5gkUjOMtkKQc0f4yuarvvDS0+HDkahAbgJwOYe437CqltmdwcbwL0eY/7icf8bAC/4Y07IKvgbVDgyH1GoF4Ztgzeny2wP4Fl4N9tbAeAfwZtT+QTWtMxirLdgkTQ3zWWCmd2p7PaiBapJVcfrgyAW4ozNFyZrldRsFdS0F60mfhfEOlUIhXIwRxUw9hoEE6P2clxeu6t7EcrIBMlPAK4sYFwPqHOxSnQ0g6Fsayxg7MWo47TljgTiZKY2NzPBWKNgT0ZEIwAADddJREFUzBbMlJyY3wexThsCqkFZxyuQh4XDzPmCMsmpaQvGpIzQtYJYx0e2gLf8eHfZGMAcAMcXMHY+8otWdod56F6Ypa4zgErExShMdLQfVJvtc4I1pyjOgap38WpyB6jdWCEOtS4IxMmYVkMfQSO2RZnNKbMlY0E6mZKRpfRrbpq2YKYUzLRzhHV2BlApbAn1j/UDqHCRnzuvdaE6VH6AwhRoAeAsBJtp09Uw3FwoHbSQYHGgDvcLSa4gUBlnDyN/h82g2RAq3f4yFHaGvQLq7CncFbcRiJMRVO/DKbMFNaWgpm1RM1/zqKpBd3PfSmZywZgtKJMyGumsn0mlsRlUlssCqEPYW6H0uwYD6FXgHBGoXdGZUG9qn0Fl2NACP38rut5iu1Duh5LwKJbwwL90fILiHsKjoHapN0BJApWKgVAh4A/h3dyuHQlV7FuLYrddxrfsso5wFulD4EhuC92wpdQc+UMQ65SaQfPm8ReHDvheUNabM9PmxKzGM5kN2q6OmT6LoWQ9VkLVNXTMBOwD1YxpLRTuUH7NCwBO6uJni2ERVEq9l8xHRySUcwopHfdDZfr9u8DxDOr353ioF5UWqMP3Vp/t6glgT6i6qgPgXQPza06G+v0L6UAgTkZEzF7clbbOTGnYts4cu6qLMDsiqPkVZ2ZPizLbYqxadjJe9Gm7gmAO1D9YEdD8v+ZuFOdkZkA5p0oiicruGHkl1E62O1wF1Rnz/CI+Y0DJBDVD/T69CnVO8hpUyLOY54wG5ei2gQr37gylCN2VZ6IL4O9QqgXlYEOo1O+KJKCdDO1lSCYNqXYyWWlV2j/iLmMx+g2n5mZShQK9Oj/WOw9CheWsEq75OIDlUG+lhVCJobLmchvgwb3ovpMBgAugGptdh+J3DRTArm1XO7xtvu+gzv5W4ufwKQWQABCDkhpaHV3fmXdEAhgP4A4f5uoqUShnWZEEs5MhrIkw2ya2lIZta/1aG2rGydjE/FYyJgVjtjAZvfq0ZM/Tr0kuL7ddFcYSACdAhTVKTQ7AAygs220JgEeCNSfEg5ugQrV3Qu1sugMDsE7bVQoWQSlNPFui9aqSQA7+OYs2CXXwbwtmLtl27qRShUoCJ2Oa31qU2ZwxKYhp29FErYTM/OIhAFujPA6mnUJVbx+FevsNKS/ToVLh/RJNLQVPABiE0MF4EoiTkYQ2CWpKTpktSW1klrVjG+w7ySKSs4gtTFNyEgtDZoqZAIZBhXq+KbMtLwP4soBxlRgqq1cWQWWSHY/KFtL9ESo8tj/CYsuCCGYnY5o9OGM2NyPSYrQkoTI3QPWCjlgmXdCenm1RZguT9S3Ful1kKoDhUEVwr6Fr6b35+B6qgn8LAHtAHfJXAi68JWK+RmGFgSGlwwUwESr78R/wlqEpJcsA/B+UbZMQ1sEUjO8P5pOve8rkjJm8bSdj0UjgTmZZIjE0leixMhPvcWXQzuaoKdcsF6a5QtXKmHaOmEFlZflBFqqm5XyoDJoeUFk0p0K9xb8KVTtjFzCXgKoZeABK0XhrAGu3/XcgMj7dQIdKRc3HPajPXj/VQArARVBp8ycAeL+MtrwD4Bgo8dUklG0hReD7wX/ESDVJFpHStnXbsaW0RaBO5sd+a57GgUuF65pw3VNTDYm1vyXa8f2/+25pUGtyYi7glPUX1JSS0UJkJiqFDJRj+XVPdQKVbcOgHFFHR52GCmUE9vMMgF3RuSJzO6GMTOWzEiot+Bao7KkRUF1Qd0BASUttvA/V9mEaQiWIbuP7/6isE+2pUds2bCF1KXRdskDilvMGDWKRrHNRFs44OGAaXFdzobsa9oauzZg/YNBx6341770g1uaULpDUXIMzanMz0juINUqMhEr7rBUO87j/FoCPS2HIKlgEFdOvZvxIXy6WuW3XBCiByu2gRDS3hVL+XgsqPbkYBFRm2xcA3oT6vXgLKgxcSTwJoGrPtn13Mm6c9ZCuKYVt6wa1pS6k707ms80Hr8Vd59ZMDJvprpOBBqq7iMBxuatrK1wNa8DVHp232fbXtfznzWuSPsdPbdP83mLMFiwiBTUbx018m04av23NZNBVOX0AjPEYM6UEdnRGK6qnMVelsgLA821XR3pC7WDvh5JS6ozZAI5E4aHicvMOKr/HTqf4v5PRSQ+NmbZh29KgQtcYWeLn/K/tMGznJa52rQ63SXNhuXA03dV+dF3neV3DEAda1NUADbrrAieN2GHY1rtRefofXnrJt74vWYP+KJkpVZo2dZbHnd6o7IyYeuIEqOK0zrCgzpVCao/lbddLyO9ktoNqPVANDqbq8f2QXJqRRk6pzVWxorRJ3Bcn4wLa87vtf2wu2nhLLh6PZWIJno7FeTbWsDgXix+33dsvjl/eEB+ZiTV8mI01WOlYnGfiCZ6NJbaWpOmRWcNG7uyHHQAgYuYP7dlznJmS6KwWQma1QCPy95IHVF1DNZ0vhRSPl8RKAt6tk0N8wncnk9NZI6cRyQm1OTXFvHmN3Raxm9rcHH1yv8MuzcUSJ6XjCTsdS/BsLGGlY/GPU7HG5iEvPDkbAIbPevqLdGzd5mw8cV/mf2MSPBNvSGTiDTc8uf9hp7jJZLe/sxMxFwoakZJQW1BmW1QPnUxlcBa8+32UU/4jpDS8AO/MwX+iRGUP9Y7vP2TbjCSESW1hRiQ32bKWltHd2pJOHXv8mi7pfWsm3jgsk0jwjNq98Ew88Yxj9Bizz1P3fd1x/N5PX2/98ckHLuKJxHmZeGJ5NtbAs7GElU0keDraOGbqxz/cOP3Qcd1KO/5qNfxkUVNY1LQ5M2XOZN2VwwjpPv0BnO0xZj6UtllIbfMlgNc9xmwOlZocEjC+OxkeYQlJTCkotQWJdOvQ//ajzxmSpg23ZWMNa2eicZ6JJng21pDNJhquPWjqreftN31Sp82PDph621PpSGxsJpaYl4kneCaa4JlonGfjjYMWx3rcceuRZ3S5Y2TL6NG2ZGyxZKbkhNmSRAsVYwwJjn9C9bzJx60Ii+jqhUIa2N0IYEjQhtQ7/jsZQuMWM23OopJT2qXYt+u62g2nXHhsLhH/RyaWoOlYgmcTDVY21rAk09Bw9hF3/PteFFBIN/aua7+JpBvH52LxB9rnSMcSPBNLxHhjzwtvPHXCiclkskvJD5ZJFyqRzIjkphk6mfKyCZTacz4EgMklsCWkMrgP3mm/FCoJZOvgzalffHUyQ2e7EWFGdGGqzCsnEiv60P+Ks66IX/G3ay/IxBKj0rGEyMQTVjYa56lI/NNsjx4nnHB98s1i5hvdkuTjb7zwxlQs/o90NLEsE43zTDxhpWMJkY7G9onkev7rmr9dU7T+mE3YQotFlEgmpT2K/XyIbzAo9QKvl4W7EGYA1hMroKRpvFgTKhvtKKgeMyE+46uTae2RapCE2ZxQW5hU5nRalAT+hAl39E81Nv0rE41vmY01WOr8JcEzsYZn0vH0aadfcnqXO2z+9Yq/vsJ79joxHWv4j5ozzrOxBisXiw9YHon/Kznh9m2Lmc+i5neC0C851d/hEfZS81S32H4YIf5wKbx7aVgALiyBLSGVxe0oTPIoBpUQ8jqU1l+YEOAjvnruQfPcXgkrNSyWy/SOpNJ9ornMcw+P3PStQj571jUPDdZcebzmIgLX1QBAc2BrcCZfdvaYmX7ZOG7iRNqrNTHG1Y29XM3VXACaprmuprmOixkNK/rem0wO81tIMigmQxWVdcadHverGR1KnNMrZRlQXRjPDNackAplUwBvoDg1gAVQrSrmQBVBfuu/WfVD2beHyWRSX7zG4INcDXu7jqOrVwgHmosVuuvccO2J+38SxLon3TB9a013joNOYmrFNmcDbb7j6DffcsJe1dBorV6dTBxKz+rwAsYuh+pVUrWyHCHd5ih0L3V9MVTx5jIoPbOr/DCqXiirkznirhlxYsSOcV13Uzjq1dR1bU2DO98k9Oabx+wSaJ/zY6a+2svNWeNcVxuoabrrAIAOuJqWdXTt7rsPHVKxfbPbqFUnMwlKr+k5KFHPdkwAB0GFvgYWONfhUO2CQ+qb2+BPyvJtAI7zYZ66oWxOpnn622u7Uj9Wc9CknIurtTmZ1xb2ST84Z1hpQlZJ19U/nfbeH204I1xA0zTNdf4XkdXfbOovH5i0bcXqktWqkxH4+SB/EdSBvQCwIYCGIuaZCuAQf00LqVJ0KM26I7o5T+hkiiRIuey8ZGnPkaBuHG3tbzXHcUH06dP33MCr2ZSvJDXNAfDUyKc//s7W9dGaq0UBwNU1V9P0zVqXOHMQxmTLSd+2q1g+h9IxCwkBVET8aKgXlrNQAUcF9ULZsihS/Xrfk2poWJqJx3k2Fl+SNhuuL7WD6cjjIzb+wNKNK7LR+KfZRIOViSV4Nhp9+tm91g8dTPXxDYChCDXKQn6JBPBXAHujfK0eQkrJ4HdbN9jh7RV/3nzGj/Fy2/I/kkl9h3dXDt3xndTY9iy3CmYyVFFqZ9eUslnWPQTyf6981zIAW5Xe5JAqg0KFvT5Ecb9ft5bD2JDuUKEP8ma3KupeQifzy+sNqOZVISHFsCuA66A0z0In4zNlO5P5H5pWkX3WWzQt7DVRPThQVf9/QdiDPaR4Xmi7TgEwAKrb5jYA1oMSXl0HqkdRKB8VUneEOxmV6rxlecwMCQnxoiJDVSEFE4fS7uoMDiBdIlv8pD+AfQHsA1UPsyZU6vKPUJl+nwKYCVVHs6BMNoaEhBTA/wNaVLz6zZBm0gAAAABJRU5ErkJggg=="
+    }
+   },
+   "cell_type": "markdown",
+   "id": "305d1216-9791-43dd-8d7f-ec90aa72a307",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# `pyEQL` Tutorial: Solid-liquid-gas Equilibrium\n",
+    "\n",
+    "![pyeql-logo.png](attachment:b51ca3f4-e8bd-4b0a-a599-5f6724ad8fe5.png)\n",
+    "\n",
+    "`pyEQL` is an open-source `python` library for solution chemistry calculations and ion properties developed by the [Kingsbury Lab](https://www.kingsburylab.org/) at Princeton University.\n",
+    "\n",
+    "[Documentation](https://pyeql.readthedocs.io/en/latest/) | [How to Install](https://pyeql.readthedocs.io/en/latest/installation.html) | [GitHub](https://github.com/KingsburyLab/pyEQL) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5aceaaf",
+   "metadata": {},
+   "source": [
+    "### Select a modeling engine\n",
+    "\n",
+    "When creating a `Solution`, you can use the `engine` keyword argument to specify which [Electrolyte Modeling Engine](https://pyeql.readthedocs.io/en/latest/engines.html) you want to use.\n",
+    "\n",
+    "- [`ideal`](https://pyeql.readthedocs.io/en/latest/engines.html#the-ideal-engine): Ideal solution model\n",
+    "- [`phreeqc`](https://pyeql.readthedocs.io/en/latest/engines.html#the-phreeqc-engine): Uses `phreeqpython` with `phreeqc.dat`\n",
+    "- [`phreeqc2026`](https://pyeql.readthedocs.io/en/latest/engines.html#the-phreeqc2026-engine): Uses `pyEQL.phreeqc` with `phreeqc.dat (v3.8)` by default\n",
+    "- [`native`](https://pyeql.readthedocs.io/en/latest/engines.html#the-native-engine-default) (default): Uses built-in Pitzer activity model (when available); falls back to other models if not\n",
+    "\n",
+    "Below, we demonstrates the soild-liquid-gas equilibrium with the `phreeqc2026` engine.\n",
+    "If you would to use a custom database, please refer to `engines` tutorial. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "747454ef",
+   "metadata": {},
+   "source": [
+    "### Create solutions with selected engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "89cdfd6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyEQL import Solution\n",
+    "engine = \"phreeqc2026\"\n",
+    "s1 = Solution({\"Ca+2\": \"1 mol/kg\", \"Cl-\": \"2 mol/kg\"}, engine=engine, volume=\"2 L\")\n",
+    "s2 = Solution({\"Ca+2\": \"1 mol/kg\", \"Cl-\": \"2 mol/kg\"}, engine=engine, volume=\"2 L\")\n",
+    "s3 = Solution({\"Ca+2\": \"1 mol/kg\", \"Cl-\": \"2 mol/kg\"}, engine=engine, volume=\"2 L\")\n",
+    "s4 = Solution({\"Ca+2\": \"1 mol/kg\", \"Cl-\": \"2 mol/kg\"}, engine=engine, volume=\"2 L\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d6ec5a8",
+   "metadata": {},
+   "source": [
+    "### Solid-liquid equilibrium"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "98bc3865",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ca_molal = 1.99411 mol\n",
+      "Cl_molar = 3.98819 mol\n",
+      "C_molar  = 0.00002 mol\n"
+     ]
+    }
+   ],
+   "source": [
+    "s1.equilibrate(solids=['Calcite'])\n",
+    "print(\n",
+    "    f\"Ca_molal = {s1.get_total_amount('Ca', 'mol'):~.5f}\\n\"\n",
+    "    f\"Cl_molar = {s1.get_total_amount('Cl', 'mol'):~.5f}\\n\"\n",
+    "    f\"C_molar  = {s1.get_total_amount('C', 'mol'):~.5f}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51936a55",
+   "metadata": {},
+   "source": [
+    "### Liquid-gas equilibrium with atmosphere"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "8da26cf5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ca_molal = 1.99410 mol\n",
+      "Cl_molar = 3.98819 mol\n",
+      "C_molar  = 0.00003 mol\n"
+     ]
+    }
+   ],
+   "source": [
+    "s2.equilibrate(atmosphere=True)\n",
+    "print(\n",
+    "    f\"Ca_molal = {s2.get_total_amount('Ca', 'mol'):~.5f}\\n\"\n",
+    "    f\"Cl_molar = {s2.get_total_amount('Cl', 'mol'):~.5f}\\n\"\n",
+    "    f\"C_molar  = {s2.get_total_amount('C', 'mol'):~.5f}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f122ab1",
+   "metadata": {},
+   "source": [
+    "### Liquid-gas equilibrium with self-defined gas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "58350a53",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ca_molal = 1.99410 mol\n",
+      "Cl_molar = 3.98819 mol\n",
+      "C_molar  = 0.00049 mol\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3.equilibrate(gases={\"CO2\": -2.0}) # in log unit\n",
+    "print(\n",
+    "    f\"Ca_molal = {s3.get_total_amount('Ca', 'mol'):~.5f}\\n\"\n",
+    "    f\"Cl_molar = {s3.get_total_amount('Cl', 'mol'):~.5f}\\n\"\n",
+    "    f\"C_molar  = {s3.get_total_amount('C', 'mol'):~.5f}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1733a59a",
+   "metadata": {},
+   "source": [
+    "### Solid-liquid-gas equilibrium"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "b3cc9475",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ca_molal = 1.99410 mol\n",
+      "Cl_molar = 3.98819 mol\n",
+      "C_molar  = 0.00005 mol\n"
+     ]
+    }
+   ],
+   "source": [
+    "s4.equilibrate(solids=[\"Alunite\"])\n",
+    "s4.equilibrate(atmosphere=True)\n",
+    "print(\n",
+    "    f\"Ca_molal = {s4.get_total_amount('Ca', 'mol'):~.5f}\\n\"\n",
+    "    f\"Cl_molar = {s4.get_total_amount('Cl', 'mol'):~.5f}\\n\"\n",
+    "    f\"C_molar  = {s4.get_total_amount('C', 'mol'):~.5f}\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/pyeql_tutorial_equilibrium.ipynb
+++ b/docs/examples/pyeql_tutorial_equilibrium.ipynb
@@ -49,17 +49,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 59,
    "id": "89cdfd6c",
    "metadata": {},
    "outputs": [],
    "source": [
     "from pyEQL import Solution\n",
-    "engine = \"phreeqc2026\"\n",
-    "s1 = Solution({\"Ca+2\": \"1 mol/kg\", \"Cl-\": \"2 mol/kg\"}, engine=engine, volume=\"2 L\")\n",
-    "s2 = Solution({\"Ca+2\": \"1 mol/kg\", \"Cl-\": \"2 mol/kg\"}, engine=engine, volume=\"2 L\")\n",
-    "s3 = Solution({\"Ca+2\": \"1 mol/kg\", \"Cl-\": \"2 mol/kg\"}, engine=engine, volume=\"2 L\")\n",
-    "s4 = Solution({\"Ca+2\": \"1 mol/kg\", \"Cl-\": \"2 mol/kg\"}, engine=engine, volume=\"2 L\")"
+    "ENGINE = \"phreeqc2026\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f004ef95",
+   "metadata": {},
+   "source": [
+    "### Create a solution without equilibrium"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "87c9d544",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ca_total = 0.99705 M\n",
+      "Cl_total = 1.99410 M\n",
+      "C_total  = 0.00000 M\n"
+     ]
+    }
+   ],
+   "source": [
+    "s1 = Solution({\"Ca+2\": \"1 mol/kg\", \"Cl-\": \"2 mol/kg\"}, engine=ENGINE)\n",
+    "print(\n",
+    "    f\"Ca_total = {s1.get_total_amount('Ca', 'M'):~.5f}\\n\"\n",
+    "    f\"Cl_total = {s1.get_total_amount('Cl', 'M'):~.5f}\\n\"\n",
+    "    f\"C_total  = {s1.get_total_amount('C', 'M'):~.5f}\"\n",
+    ")"
    ]
   },
   {
@@ -72,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 61,
    "id": "98bc3865",
    "metadata": {},
    "outputs": [
@@ -80,18 +109,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Ca_molal = 1.99411 mol\n",
-      "Cl_molar = 3.98819 mol\n",
-      "C_molar  = 0.00002 mol\n"
+      "Ca_total = 0.99706 M\n",
+      "Cl_total = 1.99410 M\n",
+      "C_total  = 0.00001 M\n"
      ]
     }
    ],
    "source": [
     "s1.equilibrate(solids=['Calcite'])\n",
     "print(\n",
-    "    f\"Ca_molal = {s1.get_total_amount('Ca', 'mol'):~.5f}\\n\"\n",
-    "    f\"Cl_molar = {s1.get_total_amount('Cl', 'mol'):~.5f}\\n\"\n",
-    "    f\"C_molar  = {s1.get_total_amount('C', 'mol'):~.5f}\"\n",
+    "    f\"Ca_total = {s1.get_total_amount('Ca', 'M'):~.5f}\\n\"\n",
+    "    f\"Cl_total = {s1.get_total_amount('Cl', 'M'):~.5f}\\n\"\n",
+    "    f\"C_total  = {s1.get_total_amount('C', 'M'):~.5f}\"\n",
     ")"
    ]
   },
@@ -105,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 62,
    "id": "8da26cf5",
    "metadata": {},
    "outputs": [
@@ -113,18 +142,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Ca_molal = 1.99410 mol\n",
-      "Cl_molar = 3.98819 mol\n",
-      "C_molar  = 0.00003 mol\n"
+      "Ca_total_ori = 0.99705 M\n",
+      "Cl_total_ori = 1.99410 M\n",
+      "O_total_ori = 55.34458 M\n",
+      "C_total_ori  = 0.00000 M\n",
+      "\n",
+      "Ca_total = 0.99705 M\n",
+      "Cl_total = 1.99410 M\n",
+      "O_total = 55.34488 M\n",
+      "C_total  = 0.00002 M\n"
      ]
     }
    ],
    "source": [
+    "s2 = Solution({\"Ca+2\": \"1 mol/kg\", \"Cl-\": \"2 mol/kg\"}, engine=ENGINE)\n",
+    "print(\n",
+    "    f\"Ca_total_ori = {s2.get_total_amount('Ca', 'M'):~.5f}\\n\"\n",
+    "    f\"Cl_total_ori = {s2.get_total_amount('Cl', 'M'):~.5f}\\n\"\n",
+    "    f\"O_total_ori = {s2.get_total_amount('O', 'M'):~.5f}\\n\"\n",
+    "    f\"C_total_ori  = {s2.get_total_amount('C', 'M'):~.5f}\\n\"\n",
+    ")\n",
     "s2.equilibrate(atmosphere=True)\n",
     "print(\n",
-    "    f\"Ca_molal = {s2.get_total_amount('Ca', 'mol'):~.5f}\\n\"\n",
-    "    f\"Cl_molar = {s2.get_total_amount('Cl', 'mol'):~.5f}\\n\"\n",
-    "    f\"C_molar  = {s2.get_total_amount('C', 'mol'):~.5f}\"\n",
+    "    f\"Ca_total = {s2.get_total_amount('Ca', 'M'):~.5f}\\n\"\n",
+    "    f\"Cl_total = {s2.get_total_amount('Cl', 'M'):~.5f}\\n\"\n",
+    "    f\"O_total = {s2.get_total_amount('O', 'M'):~.5f}\\n\"     # O2 in the atmosphere\n",
+    "    f\"C_total  = {s2.get_total_amount('C', 'M'):~.5f}\"      # CO2 in the atmosphere\n",
     ")"
    ]
   },
@@ -138,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 63,
    "id": "58350a53",
    "metadata": {},
    "outputs": [
@@ -146,18 +189,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Ca_molal = 1.99410 mol\n",
-      "Cl_molar = 3.98819 mol\n",
-      "C_molar  = 0.00049 mol\n"
+      "Ca_total = 0.99705 M\n",
+      "Cl_total = 1.99410 M\n",
+      "C_total  = 0.00024 M\n"
      ]
     }
    ],
    "source": [
-    "s3.equilibrate(gases={\"CO2\": -2.0}) # in log unit\n",
+    "s3 = Solution({\"Ca+2\": \"1 mol/kg\", \"Cl-\": \"2 mol/kg\"}, engine=ENGINE)\n",
+    "s3.equilibrate(gases={\"CO2\": -2}) # in log units\n",
     "print(\n",
-    "    f\"Ca_molal = {s3.get_total_amount('Ca', 'mol'):~.5f}\\n\"\n",
-    "    f\"Cl_molar = {s3.get_total_amount('Cl', 'mol'):~.5f}\\n\"\n",
-    "    f\"C_molar  = {s3.get_total_amount('C', 'mol'):~.5f}\"\n",
+    "    f\"Ca_total = {s3.get_total_amount('Ca', 'M'):~.5f}\\n\"\n",
+    "    f\"Cl_total = {s3.get_total_amount('Cl', 'M'):~.5f}\\n\"\n",
+    "    f\"C_total  = {s3.get_total_amount('C', 'M'):~.5f}\"\n",
     ")"
    ]
   },
@@ -171,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 64,
    "id": "b3cc9475",
    "metadata": {},
    "outputs": [
@@ -179,19 +223,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Ca_molal = 1.99410 mol\n",
-      "Cl_molar = 3.98819 mol\n",
-      "C_molar  = 0.00005 mol\n"
+      "Ca_total = 0.99705 M\n",
+      "Cl_total = 1.99410 M\n",
+      "C_total  = 0.00002 M\n"
      ]
     }
    ],
    "source": [
-    "s4.equilibrate(solids=[\"Alunite\"])\n",
+    "s4 = Solution({\"Ca+2\": \"1 mol/kg\", \"Cl-\": \"2 mol/kg\"}, engine=ENGINE)\n",
+    "s4.equilibrate(solids=['Alunite'])\n",
     "s4.equilibrate(atmosphere=True)\n",
     "print(\n",
-    "    f\"Ca_molal = {s4.get_total_amount('Ca', 'mol'):~.5f}\\n\"\n",
-    "    f\"Cl_molar = {s4.get_total_amount('Cl', 'mol'):~.5f}\\n\"\n",
-    "    f\"C_molar  = {s4.get_total_amount('C', 'mol'):~.5f}\"\n",
+    "    f\"Ca_total = {s4.get_total_amount('Ca', 'M'):~.5f}\\n\"\n",
+    "    f\"Cl_total = {s4.get_total_amount('Cl', 'M'):~.5f}\\n\"\n",
+    "    f\"C_total  = {s4.get_total_amount('C', 'M'):~.5f}\"\n",
     ")"
    ]
   }

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -50,3 +50,12 @@ examples/pyeql_tutorial_database
 :maxdepth: 2
 examples/pyeql_tutorial_carbonate
 ```
+
+## Equilibrating the Solution
+
+[View Notebook on GitHub](https://github.com/KingsburyLab/pyEQL/blob/main/docs/examples/pyeql_tutorial_equilibrium.ipynb) | Try Interactive Notebook on Binder [![Binder](https://static.mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/KingsburyLab/pyEQL/main?labpath=docs%2Fexamples%2Fpyeql_tutorial_equilibrium.ipynb)
+
+```{toctree}
+:maxdepth: 2
+examples/pyeql_tutorial_equilibrium
+```


### PR DESCRIPTION
## Summary

Major changes:

- feature 1: Add a jupyter notebook demonstrating the application of solid-liquid-gas equilibrium for `phreeqc2026` engine. 
Advances #371 

## Checklist

- [ ] Google format doc strings added.
- [ ] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] I have run the tests locally and they passed.
<!-- - [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) -->

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
