### PR TITLE
Add charge balancing tutorial notebook

### DIFF
--- a/docs/examples/pyeql_tutorial_charge_balancing.ipynb
+++ b/docs/examples/pyeql_tutorial_charge_balancing.ipynb
@@ -32,7 +32,11 @@
     "- Approach 1: `auto` which will use the majority cation or anion (i.e., that with the largest concentration) as needed\n",
     "- Approach 2: `pH` which will adjust the solution pH to balance charge\n",
     "- Approach 3: `target_ion` which will use a specified cation or anion to balance charge\n",
-    "<!-- - `pE` (not currently implemented) which will adjust the redox equilibrium to balance charge, or the name of a dissolved species e.g. 'Ca+2' or 'Cl-' that will be added/subtracted to balance charge. -->"
+    "<!-- - `pE` (not currently implemented) which will adjust the redox equilibrium to balance charge, or the name of a dissolved species e.g. 'Ca+2' or 'Cl-' that will be added/subtracted to balance charge. -->\n",
+    "\n",
+    "### Important note between `balance_charge` and `charge_balance`:\n",
+    "- The `balance_charge` *kwarg* controls how charge balancing is performed.\n",
+    "- The `charge_balance` *property* returns the net electric charge of the solution."
    ]
   },
   {
@@ -40,7 +44,7 @@
    "id": "5509e64a",
    "metadata": {},
    "source": [
-    "### Import `Solution` object"
+    "### Import `Solution` class"
    ]
   },
   {
@@ -54,6 +58,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0f87d01c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pprint import pprint"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "91c165bb",
    "metadata": {},
@@ -63,12 +77,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "4702be4f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ion_dict = {\"Na+\": \"1 mol/L\", \"K+\": \"2 mol/L\", \"SO4-2\": \"5.0 mol/L\"}"
+    "ion_dict = {\"Na+\": \"0.1 mol/L\", \"K+\": \"0.2 mol/L\", \"SO4-2\": \"0.5 mol/L\"}"
    ]
   },
   {
@@ -76,15 +90,12 @@
    "id": "ee5d0ae2",
    "metadata": {},
    "source": [
-    "### **Approach 0:** `balance_charge` = `None (default)`\n",
-    "\n",
-    "- The `balance_charge` *kwarg* controls how charge balancing is performed.\n",
-    "- The `charge_balance` *property* returns the net electric charge of the solution."
+    "### **Approach 0:** `balance_charge` = `None (default)`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "abed484d",
    "metadata": {},
    "outputs": [
@@ -92,13 +103,36 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Solution charge balance: -7.0\n"
+      "'Solution charge balance: -0.7000000000000001'\n"
      ]
     }
    ],
    "source": [
     "sol = Solution(solutes=ion_dict, pH=7)\n",
-    "print(f\"Solution charge balance: {sol.charge_balance}\")"
+    "pprint(f\"Solution charge balance: {sol.charge_balance}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9fbdc022",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'H2O(aq)': 54.72584323986092,\n",
+      " 'H[+1]': 1e-07,\n",
+      " 'K[+1]': 0.2,\n",
+      " 'Na[+1]': 0.1,\n",
+      " 'OH[-1]': 1.0000000000000001e-07,\n",
+      " 'SO4[-2]': 0.5}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(sol.components)"
    ]
   },
   {
@@ -113,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "e0b10d4e",
    "metadata": {},
    "outputs": [
@@ -121,13 +155,36 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Balance charge: auto, Solution charge balance: -1.1102230411687688e-16\n"
+      "'Balance charge: auto, Solution charge balance: 1.942890160745126e-16'\n"
      ]
     }
    ],
    "source": [
     "sol1 = Solution(solutes=ion_dict, pH=7, balance_charge=\"auto\")\n",
-    "print(f\"Balance charge: {sol1.balance_charge}, Solution charge balance: {sol1.charge_balance}\")"
+    "pprint(f\"Balance charge: {sol1.balance_charge}, Solution charge balance: {sol1.charge_balance}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "fd2c6f11",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'H2O(aq)': 54.72584323986092,\n",
+      " 'H[+1]': 1e-07,\n",
+      " 'K[+1]': 0.9000000000000001,\n",
+      " 'Na[+1]': 0.1,\n",
+      " 'OH[-1]': 1.0000000000000001e-07,\n",
+      " 'SO4[-2]': 0.5}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(sol1.components)"
    ]
   },
   {
@@ -140,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "id": "d787c7bd",
    "metadata": {},
    "outputs": [
@@ -148,13 +205,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Adjusted pH: -0.8450980400142569, Solution charge balance: 3.4778541082882235e-16\n"
+      "('Adjusted pH: 0.15490195998573425, Solution charge balance: '\n",
+      " '1.1942945879741522e-16')\n"
      ]
     }
    ],
    "source": [
     "sol2 = Solution(solutes=ion_dict, pH=7, balance_charge=\"pH\")\n",
-    "print(f\"Adjusted pH: {sol2.pH}, Solution charge balance: {sol2.charge_balance}\")"
+    "pprint(f\"Adjusted pH: {sol2.pH}, Solution charge balance: {sol2.charge_balance}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "897ae953",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'H2O(aq)': 54.86418501706463,\n",
+      " 'H[+1]': 0.7000000000000144,\n",
+      " 'K[+1]': 0.2,\n",
+      " 'Na[+1]': 0.1,\n",
+      " 'OH[-1]': 1.428571428571399e-14,\n",
+      " 'SO4[-2]': 0.5}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(sol2.components)"
    ]
   },
   {
@@ -168,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 10,
    "id": "d633c3c9",
    "metadata": {},
    "outputs": [
@@ -176,7 +257,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Charge balancing species Mg[+2] was not found in the solution!. Species {'OH[-1]', 'Na[+1]', 'SO4[-2]', 'K[+1]', 'H[+1]'} were found.\n"
+      "Charge balancing species Mg[+2] was not found in the solution!. Species {'OH[-1]', 'Na[+1]', 'SO4[-2]', 'H[+1]', 'K[+1]'} were found.\n"
      ]
     }
    ],
@@ -199,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "ead247ce",
    "metadata": {},
    "outputs": [
@@ -207,7 +288,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Balance charge: Mg[+2], Solution charge balance: -3.252606452833028e-19\n"
+      "Balance charge: Mg[+2], Solution charge balance: -1.1102231569740545e-16\n"
      ]
     }
    ],
@@ -219,6 +300,92 @@
     "    print(f\"Balance charge: {sol3.balance_charge}, Solution charge balance: {sol3.charge_balance}\")\n",
     "except Exception as e:\n",
     "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "e1d161d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'H2O(aq)': 55.231684730030274,\n",
+      " 'H[+1]': 1e-07,\n",
+      " 'K[+1]': 0.2,\n",
+      " 'Mg[+2]': 0.35,\n",
+      " 'Na[+1]': 0.1,\n",
+      " 'OH[-1]': 1.0000000000000001e-07,\n",
+      " 'SO4[-2]': 0.5}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(sol3.components)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9ee787f-ce70-4a04-9f9b-41c8345332e0",
+   "metadata": {},
+   "source": [
+    "Notice: Equilibration or `equilibrate()` may adjust the solution’s charge balance, regardless of the charge‑balancing method selected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "784b1cf7-cc92-48f7-a02e-a2767b82bd92",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Balance charge: Mg[+2], Solution charge balance: 1.0949150222941115e-14\n"
+     ]
+    }
+   ],
+   "source": [
+    "sol3.equilibrate()\n",
+    "print(f\"Balance charge: {sol3.balance_charge}, Solution charge balance: {sol3.charge_balance}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "a8bb88a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'H2(aq)': 6.68016685019436e-35,\n",
+      " 'H2O(aq)': 55.231684730030274,\n",
+      " 'H2SO4(aq)': 2.955381123583309e-17,\n",
+      " 'HSO4[-1]': 4.694880409629213e-07,\n",
+      " 'H[+1]': 1.2355429818950996e-07,\n",
+      " 'KHSO4(aq)': 2.230659291147991e-09,\n",
+      " 'KOH(aq)': 3.4346168841829974e-09,\n",
+      " 'KSO4[-1]': 0.037892500433198605,\n",
+      " 'K[+1]': 0.16210749390154605,\n",
+      " 'MgOH[+1]': 7.556375003093858e-16,\n",
+      " 'MgSO4(aq)': 0.2521686258600411,\n",
+      " 'Mg[+2]': 0.09783115190466592,\n",
+      " 'NaOH(aq)': 9.057306224711908e-10,\n",
+      " 'NaSO4[-1]': 0.017061737901742306,\n",
+      " 'Na[+1]': 0.08293826119252737,\n",
+      " 'O2(aq)': 8.24736736273411e-25,\n",
+      " 'OH[-1]': 1.4646206798488167e-07,\n",
+      " 'SO4[-2]': 0.1928766640863217}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(sol3.components)"
    ]
   }
  ],

--- a/docs/examples/pyeql_tutorial_charge_balancing.ipynb
+++ b/docs/examples/pyeql_tutorial_charge_balancing.ipynb
@@ -1,0 +1,246 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "76c3ccc7",
+   "metadata": {},
+   "source": [
+    "# `pyEQL` Tutorial: Charge balancing\n",
+    "\n",
+    "![pyEQL Logo](../../pyeql-logo.png)\n",
+    "\n",
+    "`pyEQL` is an open-source `python` library for solution chemistry calculations and ion properties developed by the [Kingsbury Lab](https://www.kingsburylab.org/) at Princeton University.\n",
+    "\n",
+    "[Documentation](https://pyeql.readthedocs.io/en/latest/) | [How to Install](https://pyeql.readthedocs.io/en/latest/installation.html) | [GitHub](https://github.com/rkingsbury/pyEQL) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d9ba4d0",
+   "metadata": {},
+   "source": [
+    "This tutorial introduces strategies for handling charge balance in a `Solution` object."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd840142",
+   "metadata": {},
+   "source": [
+    "### Charge balancing strategies\n",
+    "- Approach 0: `None (default)` in which case no charge balancing will be performed\n",
+    "- Approach 1: `auto` which will use the majority cation or anion (i.e., that with the largest concentration) as needed\n",
+    "- Approach 2: `pH` which will adjust the solution pH to balance charge\n",
+    "- Approach 3: `target_ion` which will use a specified cation or anion to balance charge\n",
+    "<!-- - `pE` (not currently implemented) which will adjust the redox equilibrium to balance charge, or the name of a dissolved species e.g. 'Ca+2' or 'Cl-' that will be added/subtracted to balance charge. -->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5509e64a",
+   "metadata": {},
+   "source": [
+    "### Import `Solution` object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ae238c71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyEQL import Solution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91c165bb",
+   "metadata": {},
+   "source": [
+    "### Example of a non-charge balanced solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4702be4f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ion_dict = {\"Na+\": \"1 mol/L\", \"K+\": \"2 mol/L\", \"SO4-2\": \"5.0 mol/L\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee5d0ae2",
+   "metadata": {},
+   "source": [
+    "### **Approach 0:** `balance_charge` = `None (default)`\n",
+    "\n",
+    "- The `balance_charge` *kwarg* controls how charge balancing is performed.\n",
+    "- The `charge_balance` *property* returns the net electric charge of the solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "abed484d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution charge balance: -7.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "sol = Solution(solutes=ion_dict, pH=7)\n",
+    "print(f\"Solution charge balance: {sol.charge_balance}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "387ae5c1",
+   "metadata": {},
+   "source": [
+    "### **Approach 1:** `balance_charge` = \"auto\"\n",
+    "\n",
+    "The `balance_charge = \"auto\"` will use the majority cation or anion (i.e., that with the largest concentration), in this case `K[+1]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e0b10d4e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Balance charge: auto, Solution charge balance: -1.1102230411687688e-16\n"
+     ]
+    }
+   ],
+   "source": [
+    "sol1 = Solution(solutes=ion_dict, pH=7, balance_charge=\"auto\")\n",
+    "print(f\"Balance charge: {sol1.balance_charge}, Solution charge balance: {sol1.charge_balance}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32164496",
+   "metadata": {},
+   "source": [
+    "### **Approach 2:** `balance_charge` = \"pH\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d787c7bd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Adjusted pH: -0.8450980400142569, Solution charge balance: 3.4778541082882235e-16\n"
+     ]
+    }
+   ],
+   "source": [
+    "sol2 = Solution(solutes=ion_dict, pH=7, balance_charge=\"pH\")\n",
+    "print(f\"Adjusted pH: {sol2.pH}, Solution charge balance: {sol2.charge_balance}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d078528c",
+   "metadata": {},
+   "source": [
+    "### **Approach 3:** `balance_charge` = \"target ion\"\n",
+    "Charge balance can also be done by designating a particular \"target ion\", in this case `Mg[+2]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d633c3c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Charge balancing species Mg[+2] was not found in the solution!. Species {'OH[-1]', 'Na[+1]', 'SO4[-2]', 'K[+1]', 'H[+1]'} were found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    sol3 = Solution(solutes=ion_dict, pH=7, balance_charge=\"Mg+2\")\n",
+    "    print(f\"Solution charge balance: {sol3.charge_balance}\")\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e29fd23b",
+   "metadata": {},
+   "source": [
+    "Notice: To use `balance_charge`, the target ion must be present in the `Solution` object. \n",
+    "We add a trace concentration (0.5 mol/L)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ead247ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Balance charge: Mg[+2], Solution charge balance: -3.252606452833028e-19\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Add target ion in Solution object with 0.5 mol/L\n",
+    "ion_dict[\"Mg+2\"] = \"0.5 mol/L\"\n",
+    "try:\n",
+    "    sol3 = Solution(solutes=ion_dict, pH=7, balance_charge=\"Mg+2\")\n",
+    "    print(f\"Balance charge: {sol3.balance_charge}, Solution charge balance: {sol3.charge_balance}\")\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "shaun_pyeql_env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -50,3 +50,7 @@ examples/pyeql_tutorial_database
 :maxdepth: 2
 examples/pyeql_tutorial_carbonate
 ```
+
+## Charge Balancing Strategies
+
+[View Notebook on GitHub](https://github.com/KingsburyLab/pyEQL/blob/main/docs/examples/pyeql_tutorial_charge_balancing.ipynb) | Try Interactive Notebook on Binder [![Binder](https://static.mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/KingsburyLab/pyEQL/main?labpath=docs%2Fexamples%2Fpyeql_charge_balancing.ipynb)


### PR DESCRIPTION
## Summary

This PR introduces a charge balancing tutorial notebook (`pyeql_tutorial_charge_balancing.ipynb`) located under docs/examples/. This PR addresses #371.

Charge balancing strategies covered in the tutorial:
- `None (default)`: No charge balancing is performed
- `auto`: Automatically balances charge using the dominant cation or anion (highest concentration)
- `pH`: Adjusts the solution pH to achieve charge balance
- `target_ion`: Balances charge by adding or removing a user‑specified ion
