### PR TITLE
Fix for ext/ now being gitignored

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ requires = ["scikit-build-core", "pybind11", "setuptools_scm[toml]>=5"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
+sdist.include = ["src/pyEQL/phreeqc/ext/**/*"]
 install.components = ["python", "iphreeqc_database"]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 


### PR DESCRIPTION
Our build backend, `scikit-build-core`, includes untracked files that aren't gitignored, in the `sdist`. Adding the ext/ path to .gitignore made them explicitly excluded.

This showed up in the CI because certain steps like the docs first build an sdist, then install `pyEQL` from there..

We should always have had this directive for robustness anyway, but better late than never..
