### PR TITLE
Handling doc warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,16 +176,9 @@ html_theme_options = {
     # "sidebar_width": "300px",
     # "page_width": "1200px",
     "site_url": "https://pyeql.readthedocs.io/en/latest/",
-    "site_name": "pyEQL documentation",
     "repo_url": "https://github.com/KingsburyLab/pyEQL/",
     "repo_name": "pyEQL",
     # 'logo_icon': 'e798',
-    "nav_links": 
-    [{
-            "title": "Releases",
-            "url": "https://github.com/KingsburyLab/pyEQL/releases",
-            "internal": False,
-    },],
     "toc_title": "pyEQL: a python interface for water chemistry",
     "palette": { "primary": "blue", "accent": "light-blue" },
     "globaltoc_collapse": True,


### PR DESCRIPTION
Some `mkdocs` related stuff is not applicable anymore and is throwing warnings, treated as errors. This is not a final fix, but hopefully good enough to keep generating docs..