### PR TITLE
Fixing CI docs error

### DIFF
--- a/docs/examples/pyeql_tutorial_charge_balancing.ipynb
+++ b/docs/examples/pyeql_tutorial_charge_balancing.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "`pyEQL` is an open-source `python` library for solution chemistry calculations and ion properties developed by the [Kingsbury Lab](https://www.kingsburylab.org/) at Princeton University.\n",
     "\n",
-    "[Documentation](https://pyeql.readthedocs.io/en/latest/) | [How to Install](https://pyeql.readthedocs.io/en/latest/installation.html) | [GitHub](https://github.com/rkingsbury/pyEQL) "
+    "[Documentation](https://pyeql.readthedocs.io/en/latest/) | [How to Install](https://pyeql.readthedocs.io/en/latest/installation.html) | [GitHub](https://github.com/KingsburyLab/pyEQL) "
    ]
   },
   {


### PR DESCRIPTION
## Summary

Changed the link from `https://github.com/rkingsbury/pyEQL` to `https://github.com/KingsburyLab/pyEQL`.