### PR TITLE
Warning issue for the configuration setting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,14 +176,14 @@ html_theme_options = {
     # "sidebar_width": "300px",
     # "page_width": "1200px",
     "site_url": "https://pyeql.readthedocs.io/en/latest/",
-    "site_name": "pyEQL documentation",
+    "nav_title": "pyEQL documentation",
     "repo_url": "https://github.com/KingsburyLab/pyEQL/",
     "repo_name": "pyEQL",
     # 'logo_icon': 'e798',
     "nav_links": 
     [{
             "title": "Releases",
-            "url": "https://github.com/KingsburyLab/pyEQL/releases",
+            "href": "https://github.com/KingsburyLab/pyEQL/releases",
             "internal": False,
     },],
     "toc_title": "pyEQL: a python interface for water chemistry",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,12 +180,13 @@ html_theme_options = {
     "repo_url": "https://github.com/KingsburyLab/pyEQL/",
     "repo_name": "pyEQL",
     # 'logo_icon': 'e798',
-    "nav_links": 
-    [{
-            "title": "Releases",
-            "href": "https://github.com/KingsburyLab/pyEQL/releases",
-            "internal": False,
-    },],
+    "social": [
+        {
+            "icon": "fontawesome/brands/github",
+            "link": "https://github.com/KingsburyLab/pyEQL/releases",
+            "name": "Releases",
+        }
+    ],
     "toc_title": "pyEQL: a python interface for water chemistry",
     "palette": { "primary": "blue", "accent": "light-blue" },
     "globaltoc_collapse": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,13 +180,11 @@ html_theme_options = {
     "repo_url": "https://github.com/KingsburyLab/pyEQL/",
     "repo_name": "pyEQL",
     # 'logo_icon': 'e798',
-    "social": [
-        {
+    "social": [{
             "icon": "fontawesome/brands/github",
             "link": "https://github.com/KingsburyLab/pyEQL/releases",
             "name": "Releases",
-        }
-    ],
+    }],
     "toc_title": "pyEQL: a python interface for water chemistry",
     "palette": { "primary": "blue", "accent": "light-blue" },
     "globaltoc_collapse": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,7 +176,7 @@ html_theme_options = {
     # "sidebar_width": "300px",
     # "page_width": "1200px",
     "site_url": "https://pyeql.readthedocs.io/en/latest/",
-    "nav_title": "pyEQL documentation",
+    "html_title": "pyEQL documentation",
     "repo_url": "https://github.com/KingsburyLab/pyEQL/",
     "repo_name": "pyEQL",
     # 'logo_icon': 'e798',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,7 +176,6 @@ html_theme_options = {
     # "sidebar_width": "300px",
     # "page_width": "1200px",
     "site_url": "https://pyeql.readthedocs.io/en/latest/",
-    "html_title": "pyEQL documentation",
     "repo_url": "https://github.com/KingsburyLab/pyEQL/",
     "repo_name": "pyEQL",
     # 'logo_icon': 'e798',
@@ -196,7 +195,7 @@ html_sidebars = {"**": ["logo-text.html", "globaltoc.html", "localtoc.html", "se
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-# html_title = None
+html_title = "pyEQL: a python interface for water chemistry"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 # html_short_title = None


### PR DESCRIPTION
## Summary

Major changes:
This PR updates unsupported theme option names in `html_theme_options`.

- fix 1: Replaced `site_name` with `nav_title`
- fix 2: Replaced `nav_links` with `social`

Fixes #370 
## Checklist

- [ ] Google format doc strings added.
- [ ] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] I have run the tests locally and they passed.
<!-- - [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) -->

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
