### PR TITLE
Only running coverage on ubuntu

### DIFF
--- a/.github/workflows/testing-pinned.yaml
+++ b/.github/workflows/testing-pinned.yaml
@@ -44,4 +44,4 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -n auto --cov=src/pyEQL --cov-report=xml --dist=loadscope
+          pytest -n auto --dist=loadscope


### PR DESCRIPTION
Looks like all runners in `testing-pinned` workflow run tests with coverage, but then discard the coverage results anyway. This is not a fix for the CI issue seen in PR #397, but should fix it anyway ;)

`testing.yml` still runs with coverage and uploads to codecov, like before.