### PR TITLE
add Br3- to standardize_formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- Added `python` 3.14 support
+- Added `python` 3.14 support (#404, @rkingsbury)
+- Docs: new charge balancing tutorial (#391, @SuixiongTay)
+- Docs: new tutorial for solid-liquid-gas equilibrium (#390, @YitongPan1)
+- `Solution.__init__` now checks whether the supplied `pH` and `pE` conditions are within
+  the electrochemical stability limits of water, and logs a warning if they are not (#385, @YitongPan1)
 
 ### Changed
 
-- migrate from `pymatgen` to `[pymatgen-core](https://github.com/materialsproject/pymatgen-core)` to reduce dependency count.
+- Solute properties are now pre-cached to enhance performance, especially when creating
+  Solutions containing a large number of solutes (#384, @rkingsbury)
+- migrate from `pymatgen` to `[pymatgen-core](https://github.com/materialsproject/pymatgen-core)` to reduce dependency count. (#403, @rkingsbury)
+
+### Fixed
+
+- `utils.standardize_formula()`: Triiodide ion now correctly renders as `Br3[-1]` rather than `Br[-0.33333333]` (#410, @rkingsbury)
+- `Solution.__init__`: fix the way the moles of solvent are initially calculated. The previous approach contained
+  an error and also used a fixed water concentration of 55.55 mol/L regardless of temperature or pressure. The
+  calculation now uses the internal `water_substance` to retrieve the correct density and calculate the molarity. The flaw in the original method did not affect quantitative results because the initial amount of moles was
+  immediately overwritten by `add_amount` during `__init__`. (#406, @rkingsbury)
+- Docs: fixed issues with the built docs (#402, @YitongPan1; #401, @SuixiongTay)
+- Packaging: remove `.gitignore`'ed files from `scikit-build-core` sdist (#392, @vineetbansal)
 
 ## Removed
 
-- Dropped `python` 3.10 support
+- Dropped `python` 3.10 support (#404, @rkingsbury)
 
 ## [1.4.0] - 2026-02-17
 

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -110,11 +110,13 @@ def standardize_formula(formula: str):
     # thiocyanate
     elif "CSN" in sform:
         sform = sform.replace("CSN", "SCN")
-    # triiodide, nitride, an phosphide
+    # triiodide, trinitride, tribromide and phosphide
     elif sform == "I[-0.33333333]":
         sform = "I3[-1]"
     elif sform == "N[-0.33333333]":
         sform = "N3[-1]"
+    elif sform == "Br[-0.33333333]":
+        sform = "Br3[-1]"
     elif sform == "P[-0.33333333]":
         sform = "P3[-1]"
     # formate

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,6 +36,7 @@ def test_standardize_formula():
     assert standardize_formula("I3-") == "I3[-1]"
     assert standardize_formula("N3-") == "N3[-1]"
     assert standardize_formula("P3-") == "P3[-1]"
+    assert standardize_formula("Br3-") == "Br3[-1]"
     assert standardize_formula("HCOO-") == "HCO2[-1]"
     assert standardize_formula("CO2-1") == "C2O4[-2]"
     assert standardize_formula("C2O4--") == "C2O4[-2]"


### PR DESCRIPTION
## Summary

Adds correct handling of tribromide ion, Br3-, to `standardize_formula`.

This is part of addressing #335 . Specifically, this fix is required to allow test_oxi_state_handling to pass after adding the `_update_volume` call to `equilibrate` in #407 .