### PR TITLE
Fix: handle np.nan

### DIFF
--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -54,6 +54,10 @@ def _translate_pint_quantity(amount: str):
         return amount.magnitude, str(amount.units)
 
     match = re.match(r"^\s*([+-]?\d*\.?\d+(?:[eE][+-]?\d+)?)\s*(.*)$", amount)
+
+    if match is None:
+        return amount
+
     _value, _unit = match.groups()
     unit = translate_units(_unit)
     return (float(_value), unit)

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -53,17 +53,16 @@ def _translate_pint_quantity(amount: str):
     if isinstance(amount, Quantity):
         return amount.magnitude, str(amount.units)
 
-    if "ppm" in amount or "ppb" in amount or "ppt" in amount or amount.strip().endswith("m"):
-        match = re.match(r"^\s*([+-]?\d*\.?\d+(?:[eE][+-]?\d+)?)\s*(.*)$", amount)
+    match = re.match(r"^\s*([+-]?\d*\.?\d+(?:[eE][+-]?\d+)?)\s*(.*)$", amount)
 
-        if match is None:
-            return amount
+    if match is None:
+        return amount
 
-        _value, _unit = match.groups()
-        unit = translate_units(_unit)
-        return float(_value), unit
-
-    return amount
+    _value, _unit = match.groups()
+    # handle python ** expression in Pint quantity
+    _value = eval(_value) if "**" in _value else float(_value)
+    unit = translate_units(_unit)
+    return (float(_value), unit)
 
 
 @lru_cache

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -53,14 +53,17 @@ def _translate_pint_quantity(amount: str):
     if isinstance(amount, Quantity):
         return amount.magnitude, str(amount.units)
 
-    match = re.match(r"^\s*([+-]?\d*\.?\d+(?:[eE][+-]?\d+)?)\s*(.*)$", amount)
+    if "ppm" in amount or "ppb" in amount or "ppt" in amount or amount.strip().endswith("m"):
+        match = re.match(r"^\s*([+-]?\d*\.?\d+(?:[eE][+-]?\d+)?)\s*(.*)$", amount)
 
-    if match is None:
-        return amount
+        if match is None:
+            return amount
 
-    _value, _unit = match.groups()
-    unit = translate_units(_unit)
-    return (float(_value), unit)
+        _value, _unit = match.groups()
+        unit = translate_units(_unit)
+        return float(_value), unit
+
+    return amount
 
 
 @lru_cache


### PR DESCRIPTION
## Summary
This PR addresses a small edge case, exemplified by the input below:

```
s1.add_amount("Mg+2", f"{np.nan} mg/L")
```
Output:
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[16], line 1
----> 1 s1.add_amount("Mg+2", f"{np.nan} mg/L")

File ~/miniforge3/envs/feynman/code/pyEQL/src/pyEQL/solution.py:1433, in Solution.add_amount(self, solute, amount)
   1415 def add_amount(self, solute: str, amount: str):
   1416     """
   1417     Add the amount of 'solute' to the parent solution.
   1418
   (...)
   1431         Nothing. The concentration of solute is modified.
   1432     """
-> 1433     Q = ureg.Quantity(*_translate_pint_quantity(amount))
   1434     # Get the current amount of the solute
   1435     current_amt = self.get_amount(solute, amount.split(" ")[1])

File ~/miniforge3/envs/feynman/code/pyEQL/src/pyEQL/utils.py:57, in _translate_pint_quantity(amount)
     54     return amount.magnitude, str(amount.units)
     56 match = re.match(r"^\s*([+-]?\d*\.?\d+(?:[eE][+-]?\d+)?)\s*(.*)$", amount)
---> 57 _value, _unit = match.groups()
     58 unit = translate_units(_unit)
     59 return (float(_value), unit)

AttributeError: 'NoneType' object has no attribute 'groups'
```