### PR TITLE
Fix parsing for `**` exponent 

### DIFF
--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -53,7 +53,7 @@ def _translate_pint_quantity(amount: str):
     if isinstance(amount, Quantity):
         return amount.magnitude, str(amount.units)
 
-    match = re.match(r"^\s*([+-]?\d*\.?\d+(?:[eE][+-]?\d+)?)\s*(.*)$", amount)
+    match = re.match(r"^\s*([0-9eE+\-*/().]+)\s*(.*)$", amount)
 
     if match is None:
         return amount

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -114,7 +114,10 @@ def test_create_water_substance():
 
 
 def test_translate_pint_quantity():
+    import pytest  # noqa: PLC0415
+
     assert _translate_pint_quantity("5mol/kg") == (5, "mol/kg")
     assert _translate_pint_quantity("0.1g/L") == (0.1, "g/L")
     assert _translate_pint_quantity("1ppb") == (1, "ug/L")
     assert _translate_pint_quantity("0.01 ppm") == (0.01, "mg/L")
+    assert _translate_pint_quantity("10**(-10.3) mol/L") == pytest.approx((5.011872336e-11, "mol/L"))


### PR DESCRIPTION
## Summary
This PR fixes the parsing of amount strings containing `**` exponent notation and adds an additional `pytest` to address that. 