### PR TITLE
Clarify transport vs. transference number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- `Solution.get_transference_number`: New method alias to `get_transport_number` (#XXX, @rkingsbury)
+- `Solution.get_transference_number`: New method alias to `get_transport_number` (#420, @rkingsbury)
 - Added `python` 3.14 support (#404, @rkingsbury)
 - Docs: new charge balancing tutorial (#391, @SuixiongTay)
 - Docs: new tutorial for solid-liquid-gas equilibrium (#390, @YitongPan1)
@@ -19,10 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `get_transport_number`: Clarify that the quantity returned by this method is really the _transference_
-  number, which is equal to the transport number whenever there are no concentration or pressure gradients. Also added a new method `get_transference_number` as an alias. (#XXX, @rkingsbury)
+  number, which is equal to the transport number whenever there are no concentration or pressure gradients. Also added
+  a new method `get_transference_number` as an alias. (#420, @rkingsbury)
 - Solute properties are now pre-cached to enhance performance, especially when creating
   Solutions containing a large number of solutes (#384, @rkingsbury)
-- migrate from `pymatgen` to `[pymatgen-core](https://github.com/materialsproject/pymatgen-core)` to reduce dependency count. (#403, @rkingsbury)
+- migrate from `pymatgen` to `[pymatgen-core](https://github.com/materialsproject/pymatgen-core)`. (#403, @rkingsbury)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
+- `Solution.get_transference_number`: New method alias to `get_transport_number` (#XXX, @rkingsbury)
 - Added `python` 3.14 support (#404, @rkingsbury)
 - Docs: new charge balancing tutorial (#391, @SuixiongTay)
 - Docs: new tutorial for solid-liquid-gas equilibrium (#390, @YitongPan1)
@@ -17,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `get_transport_number`: Clarify that the quantity returned by this method is really the _transference_
+  number, which is equal to the transport number whenever there are no concentration or pressure gradients. Also added a new method `get_transference_number` as an alias. (#XXX, @rkingsbury)
 - Solute properties are now pre-cached to enhance performance, especially when creating
   Solutions containing a large number of solutes (#384, @rkingsbury)
 - migrate from `pymatgen` to `[pymatgen-core](https://github.com/materialsproject/pymatgen-core)` to reduce dependency count. (#403, @rkingsbury)

--- a/src/pyEQL/solute.py
+++ b/src/pyEQL/solute.py
@@ -60,12 +60,10 @@ class Datum:
 @dataclass
 class Solute:
     """
-    represent each chemical species as an object containing its formal charge,
-    transport numbers, concentration, activity, etc.
+    represent each chemical species as an object containing its physicochemical properties. The Solute class stores ONLY those properties that DO NOT depend on solution composition. Solute properties such as activity coefficient or concentration that do depend on compsition are accessed via Solution class methods.
 
     Args:
-        formula: Chemical formula for the solute. Charged species must contain a + or - and (for polyvalent solutes)
-            a number representing the net charge (e.g. 'SO4-2').
+        formula: Chemical formula for the solute. Charged species must contain a + or - and (for polyvalent solutes) a number representing the net charge (e.g. 'SO4-2').
     """
 
     formula: str

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -163,10 +163,10 @@ class Solution(MSONable):
                 to None, nothing will be printed.
             default_diffusion_coeff: Diffusion coefficient value in m^2/s to use in
                 calculations when there is no diffusion coefficient for a species in the database. This affects several
-                important property calculations including conductivity and transport number, which are related to the
+                important property calculations including conductivity and transference number, which are related to the
                 weighted sums of diffusion coefficients of all species. Setting this argument to zero will exclude any
                 species that does not have a tabulated diffusion coefficient from these calculations, possibly resulting
-                in underestimation of the conductivity and/or inaccurate transport numbers.
+                in underestimation of the conductivity and/or inaccurate transference numbers.
 
                 Missing diffusion coefficients are especially likely in complex electrolytes containing, for example,
                 complexes or paired species such as NaSO4[-1]. In such cases, setting default_diffusion_coeff  to zero
@@ -2172,38 +2172,46 @@ class Solution(MSONable):
             return ureg.Quantity(val)
         return None
 
+    def get_transference_number(self, solute: str) -> Quantity:
+        """Alias of get_transport_number(). Note that the transference number is only equal to the transport number if there are no concentration or pressure gradients."""
+        return self.get_transport_number(solute)
+
     def get_transport_number(self, solute: str) -> Quantity:
-        r"""Calculate the transport number of the solute in the solution.
+        r"""Calculate the transference number of a solute in the solution. Note that this is the
+        same as the _transport_ number if (and only if) there are no concentration or pressure gradients.
 
         Args:
-            solute: Formula of the solute for which the transport number is
-                to be calculated.
+            solute: Formula of the solute for which the transference number is to be calculated.
 
         Returns:
-                The transport number of `solute`, as a dimensionless Quantity.
+                The transference number of `solute`, as a dimensionless Quantity.
 
         Notes:
-            Transport number is calculated according to :
+            Transference number is calculated according to :
 
                 .. math::
 
                     t_i = {D_i z_i^2 C_i \over \sum D_i z_i^2 C_i}
 
-                Where :math:`C_i` is the concentration in mol/L, :math:`D_i` is the diffusion
-                coefficient, and :math:`z_i` is the charge, and the summation extends
-                over all species in the solution.
+            Where :math:`C_i` is the concentration in mol/L, :math:`D_i` is the diffusion
+            coefficient, and :math:`z_i` is the charge, and the summation extends
+            over all species in the solution.
 
-                Diffusion coefficients :math:`D_i` are adjusted for the effects of temperature
-                and ionic strength using the method implemented in PHREEQC >= 3.4.
-                See `get_diffusion_coefficient for` further details.
+            Diffusion coefficients :math:`D_i` are adjusted for the effects of temperature
+            and ionic strength using the method implemented in PHREEQC >= 3.4.
+            See `get_diffusion_coefficient for` further details.
 
 
         References:
-                Geise, G. M.; Cassady, H. J.; Paul, D. R.; Logan, E.; Hickner, M. A. "Specific
-                ion effects on membrane potential and the permselectivity of ion exchange membranes.""
-                *Phys. Chem. Chem. Phys.* 2014, 16, 21673-21681.
+            Bieusheuvel, P.M.; Dykstra, J.E.; *Introduction to Physical Processes in Environmental
+            Technology*, Section 6.2. https://www.physicsofelectrochemicalprocesses.com/book.pdf.
+
+            Geise, G. M.; Cassady, H. J.; Paul, D. R.; Logan, E.; Hickner, M. A. "Specific
+            ion effects on membrane potential and the permselectivity of ion exchange membranes.""
+            *Phys. Chem. Chem. Phys.* 2014, 16, 21673-21681.
 
         See Also:
+            :py:meth:`get_transference_number`
             :py:meth:`get_diffusion_coefficient`
             :py:meth:`get_molar_conductivity`
         """
@@ -2960,7 +2968,7 @@ class Solution(MSONable):
             import pandas as pd  # noqa: PLC0415
             import plotly.express as px  # noqa: PLC0415
 
-            df = pd.DataFrame(
+            df = pd.DataFrame(  # noqa: PD901
                 {"species": list(sorted_eq_species_dict.keys()), "si": list(sorted_eq_species_dict.values())}
             )
 

--- a/tests/test_solute_properties.py
+++ b/tests/test_solute_properties.py
@@ -23,7 +23,7 @@ RTOL = 0.05
 
 class Test_transport_number:
     """
-    test get_transport_number
+    test get_transport_number and get_transference_number
     ------------------------------------------------
     """
 
@@ -34,6 +34,7 @@ class Test_transport_number:
         # The transport number of any ion should be between 0 and 1
         assert s1.get_transport_number("K+") >= 0
         assert s1.get_transport_number("K+") <= 1
+        assert s1.get_transference_number("K+") == s1.get_transport_number("K+")
 
         # The transport number of water should be 0
         assert s1.get_transport_number("H2O") == 0


### PR DESCRIPTION
## Summary

This PR clarifies the distinction between transport and transference number and adds a new `Solution.get_transference_number` method to reinforce the distinction.

The quantity historically returned by `get_transport_number` is rigorously a _transference_ number, because it implicitly assumes there are no pressure or concentration gradients in the solution. Since a `pyEQL` `Solution` only defines the state (composition) of a solution, this is always implicitly true, but this PR will help alert users to the need to interpret results carefully if they are using `pyEQL` in the context of a transport model.