### PR TITLE
Fix bug in __deepcopy__ affectting Phreeqc2026EOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Phreeqc2026EOS`: an error in the `__deepcopy__` method prevented this class from functioning properly with some
+  `Solution` methods, such as arithmetic (`+`). (#XXX, @rkingsbury)
 - `from_preset`/ `from_dict`: there was a subtle bug in the calculation of solution volumes that could cause a pH / H+
   inconsistency when re-creating solutions from `dict` or files. This primarily affected solutions with many solutes and
   the discrepancy was small in quantitative terms, but prevented some `presets` from loading correctly.

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -200,13 +200,13 @@ class Phreeqc2026EOS(EOS):
         )
         # create the PhreeqcPython instance
         self.pp = Phreeqc(database=self.phreeqc_db, database_directory=self.db_path)
-        # attributes to hold the PhreeqPython solution.
+        # attributes to hold the Phreeqc solution.
         self.ppsol = None
         # store the solution composition to see whether we need to re-instantiate the solution
         self._stored_comp = None
 
     def _setup_ppsol(self, solution: "solution.Solution") -> None:
-        """Helper method to set up a PhreeqPython solution for subsequent analysis."""
+        """Helper method to set up a Phreeqc solution for subsequent analysis."""
 
         from pyEQL.phreeqc import PHRQSol  # noqa: PLC0415
 
@@ -458,15 +458,19 @@ class Phreeqc2026EOS(EOS):
         return ureg.Quantity(0, "L")
 
     def __deepcopy__(self, memo) -> Self:
-        # custom deepcopy required because the PhreeqPython instance used by the Native and Phreeqc engines
+        # custom deepcopy required because the Phreeqc instance used by the Native and Phreeqc engines
         # is not pickle-able.
+        from pyEQL.phreeqc import IS_AVAILABLE, Phreeqc  # noqa: PLC0415
+
+        if not IS_AVAILABLE:
+            raise RuntimeError("pyEQL phreeqc support is not available in this installation")
 
         cls = self.__class__
         result = cls.__new__(cls)
         memo[id(self)] = result
         for k, v in self.__dict__.items():
             if k == "pp":
-                result.pp = PhreeqPython(database=self.phreeqc_db, database_directory=self.db_path)
+                result.pp = Phreeqc(database=self.phreeqc_db, database_directory=self.db_path)
                 continue
             setattr(result, k, copy.deepcopy(v, memo))
         return result
@@ -623,6 +627,23 @@ class PhreeqcEOS(Phreeqc2026EOS):
         """
         # TODO - find a way to access or calculate osmotic coefficient
         return ureg.Quantity(1, "dimensionless")
+
+    def __deepcopy__(self, memo) -> Self:
+        # custom deepcopy required because the PhreeqPython instance used by the Native and Phreeqc engines
+        # is not pickle-able.
+
+        if not PHREEQPYTHON_AVAILABLE:
+            raise RuntimeError("phreeqcpython support is not available in this installation")
+
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k == "pp":
+                result.pp = PhreeqPython(database=self.phreeqc_db, database_directory=self.db_path)
+                continue
+            setattr(result, k, copy.deepcopy(v, memo))
+        return result
 
 
 class NativeEOS(PhreeqcEOS):

--- a/tests/test_engine_phreeqc.py
+++ b/tests/test_engine_phreeqc.py
@@ -6,6 +6,7 @@ This file contains tests for the volume and concentration-related methods
 used by pyEQL's Solution class using the `phreeqc` engine (phreeqpython)
 """
 
+import copy
 import logging
 
 import numpy as np
@@ -429,3 +430,17 @@ def test_equilibrate_with_atm():
     assert np.isclose(s1.get_amount("CO2(aq)", "mol/kg").magnitude, 0.00001429, atol=1e-6)  # PHREQCUI - 1.429e-05
     assert np.isclose(s1.get_amount("O2(aq)", "mol/kg").magnitude, 0.0002683, atol=1e-6)  # PHREEQCUI - 2.683e-04
     assert np.isclose(s1.get_amount("N2(aq)", "mol/kg").magnitude, 0)  # PHREEQCUI - 0
+
+
+def test_deepcopy(s2):
+    s2_copy = copy.deepcopy(s2)
+    assert s2.components == s2_copy.components
+    assert s2.volume == s2_copy.volume
+    assert s2.solvent == s2_copy.solvent
+    assert s2.temperature == s2_copy.temperature
+    assert s2.pressure == s2_copy.pressure
+    assert s2.engine.__class__ == s2_copy.engine.__class__
+    assert s2.engine.pp.__class__ == s2_copy.engine.pp.__class__
+    # addition implicitly uses the deepcopy method, so we can also test that here
+    assert (s2 + s2).components.keys() == s2.components.keys()
+    assert (s2 + s2).volume == 2 * s2.volume

--- a/tests/test_engine_phreeqc2026.py
+++ b/tests/test_engine_phreeqc2026.py
@@ -6,6 +6,7 @@ This file contains tests for the volume and concentration-related methods
 used by pyEQL's Solution class using the `phreeqc2026` engine.
 """
 
+import copy
 import logging
 
 import numpy as np
@@ -434,3 +435,17 @@ def test_equilibrate_with_atm():
     assert np.isclose(s1.get_amount("CO2(aq)", "mol/kg").magnitude, 0.00001429, atol=1e-6)  # PHREQCUI - 1.429e-05
     assert np.isclose(s1.get_amount("O2(aq)", "mol/kg").magnitude, 0.0002683, atol=1e-6)  # PHREEQCUI - 2.683e-04
     assert np.isclose(s1.get_amount("N2(aq)", "mol/kg").magnitude, 0)  # PHREEQCUI - 0
+
+
+def test_deepcopy(s2):
+    s2_copy = copy.deepcopy(s2)
+    assert s2.components == s2_copy.components
+    assert s2.volume == s2_copy.volume
+    assert s2.solvent == s2_copy.solvent
+    assert s2.temperature == s2_copy.temperature
+    assert s2.pressure == s2_copy.pressure
+    assert s2.engine.__class__ == s2_copy.engine.__class__
+    assert s2.engine.pp.__class__ == s2_copy.engine.pp.__class__
+    # addition implicitly uses the deepcopy method, so we can also test that here
+    assert (s2 + s2).components.keys() == s2.components.keys()
+    assert (s2 + s2).volume == 2 * s2.volume


### PR DESCRIPTION
This PR fixes a bug in the `__deepcopy__` method of `Phreeqc2026EOS` that prevented arithmetic operations (e.g., adding solutions) from working properly.