### PR TITLE
`NativeEOS.equilibrate`: switch to `Phreeqc2026EOS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `NativeEOS`: the `native` modeling engine (the default) now uses the natively-developed `Phreeqc2026EOS` for speciation
+  calculations, rather than the legacy `PhreeqcEOS` which was based on `phreeqpython`. Both PHREEQC wrappers are still
+  available; the only thing that has changed in this release is which one the `native` modeling engine uses. (#422, @rkingsbury)
 - `get_transport_number`: Clarify that the quantity returned by this method is really the _transference_
   number, which is equal to the transport number whenever there are no concentration or pressure gradients. Also added
   a new method `get_transference_number` as an alias. (#420, @rkingsbury)
@@ -28,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Phreeqc2026EOS`: an error in the `__deepcopy__` method prevented this class from functioning properly with some
-  `Solution` methods, such as arithmetic (`+`). (#XXX, @rkingsbury)
+  `Solution` methods, such as arithmetic (`+`). (#421, @rkingsbury)
 - `from_preset`/ `from_dict`: there was a subtle bug in the calculation of solution volumes that could cause a pH / H+
   inconsistency when re-creating solutions from `dict` or files. This primarily affected solutions with many solutes and
   the discrepancy was small in quantitative terms, but prevented some `presets` from loading correctly.

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -38,7 +38,7 @@ version `0.6.0`.
 
 ### Activity and osmotic coefficients
 
-Activity coefficients are calculated using the "effetive Pitzer model" of [Mistry et al.](https://doi.org/10.1016/j.desal.2013.03.015)
+Activity coefficients are calculated using the "effective Pitzer model" of [Mistry et al.](https://doi.org/10.1016/j.desal.2013.03.015)
 when possible. `pyEQL` selects parameters by identifying the predominant salt in the
 solution (see [Salt Matching](amounts.md#salt-vs-solute-concentrations)). The ionic
 strength is calculated based on all solutes, but only the predominant salt parameters
@@ -59,23 +59,23 @@ If data are not available, the volume for that solute is not accounted for.
 
 ### Speciation
 
-Speciation calculations are provided by PHREEQC via `phreeqpython`. We use the `llnl.dat`
-PHREEQC database due to its applicability for moderate salinity water and the large
-number of species included (see [Lu et al.](https://doi.org/10.1016/j.earscirev.2021.103888)).
-See `pyEQL.equilibrium.eqiulibrate_phreeqc` in the [module reference](internal.md#speciation-functions)
+Speciation calculations are provided by PHREEQC via our natively-developed IPHREEQC wrapper [`pyEQL.phreeqc`](https://github.com/KingsburyLab/pyEQL/tree/main/src/pyEQL/phreeqc).
+This wrapper powers the [`phreeqc2026` engine](#the-phreeqc2026-engine), described below. In the `native` engine, in
+contrast to the `phreeqc2026` engine, we use the `llnl.dat` PHREEQC database due to its superior accuracy for moderate salinity
+water and the large number of species included (see [Lu et al.](https://doi.org/10.1016/j.earscirev.2021.103888)).
+See `pyEQL.engine.Phreeqc2026EOS.equilibrate()` in the [module reference](internal.md#speciation-functions)
 for more details.
 
 ```{warning}
-Speciation support was added to the `native` engine in `v0.8.0` and should be considered
-experimental. Specifically, because the `native` engine uses a non-Pitzer PHREEQC database
-for speciation but uses the Pitzer model (when possible) for activity coefficients. As such,
-there may be subtle thermodynamic inconsistencies between the activities and the equilibrium
+The `native` engine is an engineering model designed to represent moderate to high salinity brines as accurately as
+possible. Because it uses a non-Pitzer PHREEQC database for speciation but uses the Pitzer model (when possible) for
+activity coefficients, there may be subtle thermodynamic inconsistencies between the activities and the equilibrium
 concentrations returned by `equilibrate()`.
 ```
 
 ## The `'phreeqc2026'` engine
 
-The `phreeqc2026` engine uses [`pyEQL.phreeqc`](https://github.com/KingsburyLab/pyEQL/tree/d323606e022825737c1663ee620dfa6180d2bebb/src/pyEQL/phreeqc)
+The `phreeqc2026` engine uses [`pyEQL.phreeqc`](https://github.com/KingsburyLab/pyEQL/tree/main/src/pyEQL/phreeqc)
 for speciation, activity, and volume calculations. The PHREEQC engine
 uses the `phreeqc.dat (v3.8)` PHREEQC database by default, although it is possible to instantiate
 the engine with other databases such as `llnl.dat`, `pitzer.dat`, `vitens.dat`, `wateq4f_PWN.dat`, and `geothermal.dat`. See
@@ -98,7 +98,7 @@ Older version provided in `pyEQL.equilibrium.equilibrate_phreeqc` has been remov
 Activity coefficients are calculated by dividing the PHREEQC activity by the molal
 concentration of the solute.
 
-Due to limitations in the `phreeqpython` interface, the osmotic coefficient is always
+Due to limitations in the [`phreeqpython`](https://github.com/Vitens/phreeqpython) interface, the osmotic coefficient is always
 returned as 1 at present.
 
 ```{warning}
@@ -109,20 +109,20 @@ make it difficult to access these properties.
 
 ### Solute volumes
 
-Due to limitations in the `phreeqpython` interface, solute volumes are ignored (as in
+Due to limitations in the [`phreeqpython`](https://github.com/Vitens/phreeqpython) interface, solute volumes are ignored (as in
 the `ideal` engine). More
 research is needed to determine whether this is consistent with intended PHREEQC behavior
 (when using the default database) or not.
 
 ```{warning}
 The `phreeqc` engine currently returns an osmotic coefficient of 1 and solute volume of
-0 for all solutions. There appear to be limitations in the `phreeqpython` interface that
+0 for all solutions. There appear to be limitations in the [`phreeqpython`](https://github.com/Vitens/phreeqpython) interface that
 make it difficult to access these properties.
 ```
 
 ### Speciation
 
-Speciation calculations are provided by PHREEQC via `phreeqpython`.
+Speciation calculations are provided by PHREEQC via [`phreeqpython`](https://github.com/Vitens/phreeqpython).
 
 ## The `'ideal'` engine
 

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -363,6 +363,9 @@ class Phreeqc2026EOS(EOS):
         # log a message if any components were not touched by PHREEQC
         # if that was the case, re-adjust the charge balance to account for those species (since PHREEQC did not)
         missing_species = set(self._stored_comp.keys()) - {standardize_formula(s) for s in self.ppsol.species}
+        # remove H2O(aq), because Phreeqc2026EOS does not include this species in ppsol.species. Leaving it can
+        # result in false positives.
+        missing_species.discard("H2O(aq)")
         if len(missing_species) > 0:
             logger.warning(
                 f"After equilibration, the amounts of species {sorted(missing_species)} were not modified "
@@ -646,7 +649,7 @@ class PhreeqcEOS(Phreeqc2026EOS):
         return result
 
 
-class NativeEOS(PhreeqcEOS):
+class NativeEOS(Phreeqc2026EOS):
     """
     pyEQL's native EOS. Uses the Pitzer model when possible, falls
     back to other models (e.g. Debye-Huckel) based on ionic strength
@@ -671,25 +674,7 @@ class NativeEOS(PhreeqcEOS):
                 may offer improved prediction of LSI but currently these databases are not
                 usable because they do not allow for conductivity calculations.
         """
-        self.phreeqc_db = phreeqc_db
-        # database files in this list are not distributed with phreeqpython
-        self.db_path = (
-            Path(os.path.dirname(__file__)) / "database" if self.phreeqc_db in ["llnl.dat", "geothermal.dat"] else None
-        )
-        # create the PhreeqcPython instance
-        # try/except added to catch unsupported architectures, such as Apple Silicon
-        try:
-            self.pp = PhreeqPython(database=self.phreeqc_db, database_directory=self.db_path)
-        except OSError:
-            logger.error(
-                "OSError encountered when trying to instantiate phreeqpython. Most likely this means you"
-                " are running on an architecture that is not supported by PHREEQC, such as Apple M1/M2 chips."
-                " pyEQL will work, but equilibrate() will have no effect."
-            )
-        # attributes to hold the PhreeqPython solution.
-        self.ppsol = None
-        # store the solution composition to see whether we need to re-instantiate the solution
-        self._stored_comp = None
+        super().__init__(phreeqc_db=phreeqc_db)
 
     def get_activity_coefficient(self, solution: "solution.Solution", solute: str):
         r"""

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -587,7 +587,7 @@ def test_components_by_element(s1, s2):
     # so we can't do a precise test of the order of the species in the lists.
     assert result.keys() == expected.keys()
     for element, species_list in expected.items():
-        if element == "O(-2.0)":
+        if element == "O(-2.0)" or element == "Cl(3.0)":
             # for this particular element and oxidation state, the order of the species in the list is not guaranteed
             assert set(result[element]) == set(species_list), f"Mismatch for element '{element}'"
         else:
@@ -670,7 +670,7 @@ def test_components_by_element_nested(s1, s2):
     assert result.keys() == expected.keys()
     for element, oxidation_states in expected.items():
         for oxi_state in oxidation_states:
-            if element == "O" and oxi_state == -2.0:
+            if (element == "O" and oxi_state == -2.0) or (element == "Cl" and oxi_state == 3.0):
                 # for this particular element and oxidation state, the order of the species in the list is not guaranteed
                 assert set(result[element][oxi_state]) == set(expected[element][oxi_state]), (
                     f"Mismatch for element '{element}', oxidation state {oxi_state}"

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -557,7 +557,8 @@ def test_components_by_element(s1, s2):
         pytest.skip(reason="Phreeqpython not available")
 
     s2.equilibrate()
-    assert s2.get_components_by_element() == {
+
+    expected = {
         "H(1.0)": ["H2O(aq)", "OH[-1]", "H[+1]", "HCl(aq)", "NaOH(aq)", "HClO(aq)", "HClO2(aq)"],
         "H(0.0)": ["H2(aq)"],
         "O(-2.0)": [
@@ -579,6 +580,18 @@ def test_components_by_element(s1, s2):
         "Cl(5.0)": ["ClO3[-1]"],
         "Cl(7.0)": ["ClO4[-1]"],
     }
+
+    result = s2.get_components_by_element(nested=False)
+
+    # Note: in this test, the amounts of several chloride species are zero, making their sort order arbitrary
+    # so we can't do a precise test of the order of the species in the lists.
+    assert result.keys() == expected.keys()
+    for element, species_list in expected.items():
+        if element == "O(-2.0)":
+            # for this particular element and oxidation state, the order of the species in the list is not guaranteed
+            assert set(result[element]) == set(species_list), f"Mismatch for element '{element}'"
+        else:
+            assert result[element] == species_list, f"Mismatch for element '{element}'"
 
 
 def test_components_by_element_nested(s1, s2):
@@ -611,7 +624,9 @@ def test_components_by_element_nested(s1, s2):
 
     s2.equilibrate()
 
-    assert s2.get_components_by_element(nested=True) == {
+    # Note: in this test, the amounts of several chloride species are zero, making their sort order arbitrary
+    # so we can't do a precise test of the order of the species in the lists.
+    expected = {
         "H": {
             1.0: [
                 "H2O(aq)",
@@ -632,9 +647,9 @@ def test_components_by_element_nested(s1, s2):
                 "HClO(aq)",
                 "ClO[-1]",
                 "ClO2[-1]",
-                "ClO3[-1]",
-                "ClO4[-1]",
                 "HClO2(aq)",
+                "ClO4[-1]",
+                "ClO3[-1]",
             ],
             0.0: ["O2(aq)"],
         },
@@ -649,6 +664,21 @@ def test_components_by_element_nested(s1, s2):
             7.0: ["ClO4[-1]"],
         },
     }
+
+    result = s2.get_components_by_element(nested=True)
+
+    assert result.keys() == expected.keys()
+    for element, oxidation_states in expected.items():
+        for oxi_state in oxidation_states:
+            if element == "O" and oxi_state == -2.0:
+                # for this particular element and oxidation state, the order of the species in the list is not guaranteed
+                assert set(result[element][oxi_state]) == set(expected[element][oxi_state]), (
+                    f"Mismatch for element '{element}', oxidation state {oxi_state}"
+                )
+            else:
+                assert result[element][oxi_state] == expected[element][oxi_state], (
+                    f"Mismatch for element '{element}', oxidation state {oxi_state}"
+                )
 
 
 def test_get_total_amount(s2):


### PR DESCRIPTION
## Summary

This PR simply changes the PHREEQC wrapper that the `native` (default) modeling engine uses from the legacy `phreeqpython` based one to the new, internally-developed `Phreeqc2026EOS` released in v1.4.

It also includes a small bugfix related to whether `H2O(aq)` is counted during the "missing species" check inside `Phreeqc2026EOS.equilibrate()`.