### PR TITLE
docs: ignore doi.org in linkcheck, treat timeouts as non-broken

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,7 +103,7 @@ copyright = "2023, Ryan Kingsbury"
 #
 # version: The short X.Y version.
 # release: The full version, including alpha/beta/rc tags.
-# If you don’t need the separation provided between version and release,
+# If you don't need the separation provided between version and release,
 # just set them both to the same value.
 try:
     from pyEQL import __version__ as version
@@ -318,7 +318,13 @@ linkcheck_allowed_redirects = {
     r"https://tox\.wiki": r"https://tox\.wiki/.*",
 }
 # https://idst.inl.gov/ is reachable, just not from the github runner.
-linkcheck_ignore = [r"https://localhost:\d+/", r"^https://idst\.inl\.gov/$"]
+# doi.org links are skipped because DOI redirects reliably trigger 403s from
+# publisher sites (e.g. Elsevier, Wiley, ACS) when accessed from CI runners.
+linkcheck_ignore = [r"https://localhost:\d+/", r"^https://idst\.inl\.gov/$", r"https://doi\.org/.*"]
+# Treat timeouts as non-broken so transient CI network issues don't fail the build.
+linkcheck_report_timeouts_as_broken = False
+# Retry flaky links a few times before reporting failure.
+linkcheck_retries = 3
 linkcheck_rate_limit_timeout = 500
 
 print(f"loading configurations for {project} {version} ...", file=sys.stderr)


### PR DESCRIPTION
## Summary

The `links` tox environment runs `sphinx-build -W -b linkcheck`, which treats all warnings as errors. Two categories of spurious failures were identified:

1. **403 errors from DOI redirects** — `doi.org` links redirect to publisher sites (Elsevier, Wiley, ACS, etc.) that block CI runners with 403 responses. The links themselves are valid; the publishers just reject automated requests.
2. **Transient timeouts** — intermittent network timeouts in CI emit a warning that `-W` converts to a build error, causing flaky failures unrelated to the actual content.

## Changes to `docs/conf.py`

- Added `r"https://doi\.org/.*"` to `linkcheck_ignore` so DOI links are skipped entirely during link checking
- Set `linkcheck_report_timeouts_as_broken = False` so timeout events are reported as `timeout` status (not `broken`), which does not emit a warning and therefore does not trigger `-W`
- Set `linkcheck_retries = 3` to give flaky links a few chances before reporting failure

Additional domains (e.g. ACS, Wiley, Elsevier) can be appended to `linkcheck_ignore` as they are identified.

This PR was authored by OpenAI Claude