### PR TITLE
Hiding all IPhreeqc symbols by default from our custom static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,19 @@ if(PYEQL_ENABLE_EXT)
     include_directories(${IPHREEQC_INCLUDE_DIRS})
     set(IPHREEQC_BUILD_DIR   ${IPHREEQC_BASE}/build)
     add_subdirectory(${IPHREEQC_DIR} ${IPHREEQC_BUILD_DIR})
-    set_target_properties(IPhreeqc PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+    # Hide IPhreeqc's symbols when it is statically linked into _phreeqc.so.
+    # Upstream IPhreeqc does not build with -fvisibility=hidden, so without
+    # this every Phreeqc/IPhreeqcLib symbol gets re-exported from _phreeqc.so.
+    # That collides with phreeqpython's own copy of IPhreeqc (a different
+    # build), causing segfault once both modules are loaded in the same Python
+    # process.
+    # See https://linuxvox.com/blog/c-fvisibility-hidden-fvisibility-inlines-hidden/
+    set_target_properties(IPhreeqc PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        C_VISIBILITY_PRESET hidden
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON)
     # -------------------------------------------------------
 
     # -------------------------------------------------------


### PR DESCRIPTION
I'm pretty sure all the segfaults and hanging-up that we're seeing in PR #397 is because the `from pyEQL.phreeqc import PHRQSol` has been moved to the module level, meaning it runs unconditionally.

While this in itself should not be a problem at the python level, the fact that we're seeing segfaults means that our C++ extension is clashing with the `Phreeqc`'s extension - both our library and `PhreeqcPython` are making the same symbols available in the python process, and since we differ in our mutual versions of `IPhreeqc` that we depend on, things are getting weird. I'm not sure why this would only happen on a Mac, but that's an operating system nuance that we can take as a given.

In other words, both our extension and `PhreeqcPython` are being sloppy in hiding stuff in `IPhreeqc` that we haven't provided wrappers for (and should thus remain hidden). This PR fixes that from our end.

We could ask Shaun to move the `import` where it is actually used instead of globally to get around this, but really he (or other python programmers) shouldn't have to worry about this kind of stuff.

Some more details are [here](https://linuxvox.com/blog/c-fvisibility-hidden-fvisibility-inlines-hidden/). This is all conjecture, but this change shouldn't hurt anything, and is good hygiene for us anyway. It will be interesting to see if PR #397 starts to work after these changes are merged.