### PR TITLE
equilibrate: add test and rm spurious line for pE / redox behavior

### DIFF
--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -219,8 +219,9 @@ class Phreeqc2026EOS(EOS):
             "temp": solution.temperature.to("degC").magnitude,
             "units": "mol/kgw",  # to avoid confusion about volume, use mol/kgw which seems more robust in PHREEQC
             "pH": solution.pH,
+            # PHREEQC will use the specified (fixed) pE value during equlibrate, as long
+            # as no "redox" line is specified here.
             "pe": solution.pE,
-            "redox": "pe",  # hard-coded to use the pe
             # PHREEQC will assume 1 kg if not specified, there is also no direct way to specify volume, so we
             # really have to specify the solvent mass in 1 liter of solution
             "water": solv_mass,
@@ -422,7 +423,7 @@ class Phreeqc2026EOS(EOS):
         # note that if balance_charge is set, it will have been passed to PHREEQC, so
         # the only reason to re-adjust charge balance here is to account for any missing species.
         solution._adjust_charge_balance()
-    
+
         # set the volume update flag so that the volume will be consistent with the new composition.
         solution.volume_update_required = True
 

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -745,6 +745,20 @@ def test_equilibrate(s1, s2, s5_pH):
     assert np.isclose(s5_pH.pE, orig_pE)
 
 
+def test_redox():
+    # compare pE 0 and pE 10. higher pE should have more oxidized species
+    s1 = Solution({"Na[+]": "1 mg/L", "S[-2]": "1 mg/L"}, balance_charge="pH", pH=7, pE=0, engine="native")
+    s2 = Solution({"Na[+]": "1 mg/L", "S[-2]": "1 mg/L"}, balance_charge="pH", pH=7, pE=10, engine="native")
+    s1.equilibrate()
+    s2.equilibrate()
+    assert np.isclose(s1.get_total_amount("S", "mg/L").magnitude, s2.get_total_amount("S", "mg/L").magnitude, atol=1e-3)
+    assert s1.get_total_amount("S(-2)", "mg/L").magnitude > s2.get_total_amount("S(-2)", "mg/L").magnitude
+    assert s1.get_total_amount("S(-0.4)", "mg/L").magnitude < s2.get_total_amount("S(-0.4)", "mg/L").magnitude
+    # if oxygen is present, sulfate should form even at pE=0
+    s1.equilibrate(atmosphere=True)
+    assert s1.get_total_amount("S(6)", "mg/L").magnitude > 0
+
+
 def test_tds(s1, s2, s5):
     assert s1.total_dissolved_solids.magnitude == 0
     assert np.isclose(s2.total_dissolved_solids.magnitude, 4 * 58442.769)


### PR DESCRIPTION
## Summary

This PR adds a test to verify redox behavior in `equilibrate`.

Major changes:

- remove an unnecessary `redox` line from the PHREEQC input dict in `engines.py`
- Add `test_redox` to `test_solution.py` to verify correct behavior of `equilibrate` when the `pE` argument varies.