### PR TITLE
Filter zero concentration sollutes from PHREEQC output

### DIFF
--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -364,6 +364,12 @@ class Phreeqc2026EOS(EOS):
         # use the output from PHREEQC to update the Solution composition
         # the .species_moles attribute should return MOLES (not moles per ___)
         for s, mol in self.ppsol.species_moles.items():
+            # during some redox equlibration calculations, PHREEQC will return species
+            # with amounts that are exactly zero. These species often have oxidation states
+            # that are difficult for Solute to parse, which then causes errors in some
+            # downstream methods. Ignore anything that has a zero concentration.
+            if mol == 0:
+                continue
             solution.components[s] = mol
 
         # log a message if any components were not touched by PHREEQC

--- a/tests/test_engine_phreeqc.py
+++ b/tests/test_engine_phreeqc.py
@@ -430,6 +430,9 @@ def test_equilibrate_with_atm():
     assert np.isclose(s1.get_amount("CO2(aq)", "mol/kg").magnitude, 0.00001429, atol=1e-6)  # PHREQCUI - 1.429e-05
     assert np.isclose(s1.get_amount("O2(aq)", "mol/kg").magnitude, 0.0002683, atol=1e-6)  # PHREEQCUI - 2.683e-04
     assert np.isclose(s1.get_amount("N2(aq)", "mol/kg").magnitude, 0)  # PHREEQCUI - 0
+    # for some reason, gas-equilibrium can result in zero concentration solutes. These should be
+    # filtered out.
+    assert not any(v == 0 for v in s1.components.values())
 
 
 def test_deepcopy(s2):

--- a/tests/test_engine_phreeqc2026.py
+++ b/tests/test_engine_phreeqc2026.py
@@ -435,6 +435,9 @@ def test_equilibrate_with_atm():
     assert np.isclose(s1.get_amount("CO2(aq)", "mol/kg").magnitude, 0.00001429, atol=1e-6)  # PHREQCUI - 1.429e-05
     assert np.isclose(s1.get_amount("O2(aq)", "mol/kg").magnitude, 0.0002683, atol=1e-6)  # PHREEQCUI - 2.683e-04
     assert np.isclose(s1.get_amount("N2(aq)", "mol/kg").magnitude, 0)  # PHREEQCUI - 0
+    # for some reason, gas-equilibrium can result in zero concentration solutes. These should be
+    # filtered out.
+    assert not any(v == 0 for v in s1.components.values())
 
 
 def test_deepcopy(s2):

--- a/tests/test_salt_matching.py
+++ b/tests/test_salt_matching.py
@@ -166,6 +166,15 @@ def test_salt_with_equilibration() -> None:
     assert s1.get_salt().formula == "MgCl2"
     assert np.isclose(s1.get_salt_dict(cutoff=0.0)["MgCl2"]["mol"], 1)
 
+    # https://github.com/KingsburyLab/pyEQL/issues/431
+    # test a preset solution with a complex composition
+    s2 = pyEQL.Solution.from_preset("refining")
+    d = s2.get_salt_dict(use_totals=True)
+    assert d != {}
+    assert np.isclose(d["CaSO4"]["mol"], s2.get_total_amount("Ca", "mol").magnitude)
+    d = s2.get_salt_dict(use_totals=False)
+    assert "NaNaSO4" not in d
+
 
 def test_salt_asymmetric() -> None:
     """

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -559,7 +559,7 @@ def test_components_by_element(s1, s2):
     s2.equilibrate()
 
     expected = {
-        "H(1.0)": ["H2O(aq)", "OH[-1]", "H[+1]", "HCl(aq)", "NaOH(aq)", "HClO(aq)", "HClO2(aq)"],
+        "H(1.0)": ["H2O(aq)", "OH[-1]", "H[+1]", "HCl(aq)", "NaOH(aq)", "HClO(aq)"],
         "H(0.0)": ["H2(aq)"],
         "O(-2.0)": [
             "H2O(aq)",
@@ -567,31 +567,14 @@ def test_components_by_element(s1, s2):
             "NaOH(aq)",
             "HClO(aq)",
             "ClO[-1]",
-            "ClO2[-1]",
-            "ClO3[-1]",
-            "ClO4[-1]",
-            "HClO2(aq)",
         ],
         "O(0.0)": ["O2(aq)"],
         "Na(1.0)": ["Na[+1]", "NaCl(aq)", "NaOH(aq)"],
         "Cl(-1.0)": ["Cl[-1]", "NaCl(aq)", "HCl(aq)"],
         "Cl(1.0)": ["HClO(aq)", "ClO[-1]"],
-        "Cl(3.0)": ["ClO2[-1]", "HClO2(aq)"],
-        "Cl(5.0)": ["ClO3[-1]"],
-        "Cl(7.0)": ["ClO4[-1]"],
     }
 
-    result = s2.get_components_by_element(nested=False)
-
-    # Note: in this test, the amounts of several chloride species are zero, making their sort order arbitrary
-    # so we can't do a precise test of the order of the species in the lists.
-    assert result.keys() == expected.keys()
-    for element, species_list in expected.items():
-        if element == "O(-2.0)" or element == "Cl(3.0)":
-            # for this particular element and oxidation state, the order of the species in the list is not guaranteed
-            assert set(result[element]) == set(species_list), f"Mismatch for element '{element}'"
-        else:
-            assert result[element] == species_list, f"Mismatch for element '{element}'"
+    assert s2.get_components_by_element(nested=False) == expected
 
 
 def test_components_by_element_nested(s1, s2):
@@ -624,8 +607,6 @@ def test_components_by_element_nested(s1, s2):
 
     s2.equilibrate()
 
-    # Note: in this test, the amounts of several chloride species are zero, making their sort order arbitrary
-    # so we can't do a precise test of the order of the species in the lists.
     expected = {
         "H": {
             1.0: [
@@ -635,7 +616,6 @@ def test_components_by_element_nested(s1, s2):
                 "HCl(aq)",
                 "NaOH(aq)",
                 "HClO(aq)",
-                "HClO2(aq)",
             ],
             0.0: ["H2(aq)"],
         },
@@ -646,10 +626,6 @@ def test_components_by_element_nested(s1, s2):
                 "NaOH(aq)",
                 "HClO(aq)",
                 "ClO[-1]",
-                "ClO2[-1]",
-                "HClO2(aq)",
-                "ClO4[-1]",
-                "ClO3[-1]",
             ],
             0.0: ["O2(aq)"],
         },
@@ -659,9 +635,6 @@ def test_components_by_element_nested(s1, s2):
         "Cl": {
             -1.0: ["Cl[-1]", "NaCl(aq)", "HCl(aq)"],
             1.0: ["HClO(aq)", "ClO[-1]"],
-            3.0: ["ClO2[-1]", "HClO2(aq)"],
-            5.0: ["ClO3[-1]"],
-            7.0: ["ClO4[-1]"],
         },
     }
 


### PR DESCRIPTION
## Summary

During some redox equlibration calculations, PHREEQC will return species with amounts that are exactly zero. These species often have oxidation states that are difficult for Solute to parse, which then causes errors in some downstream methods. This PR filters out zero concentration solutes to prevent them from being passed back to `Solution`.

### Primary bug being addressed by this PR

```
>>> from pyEQL import Solution, __version__
>>> s = Solution({'Na+': '1 mol/L', "SO4-2": "0.5 M"}, pH=7, pE=4, balance_charge='auto')
>>> s.equilibrate(atmosphere=True)
/home/ryan/miniforge3/envs/feynman/code/pyEQL/src/pyEQL/solute.py:127: UserWarning: Guessing oxi states failed for SO2[-0.66666667]
  warnings.warn(f"Guessing oxi states failed for {formula}")
>>> from pprint import pprint
>>> pprint(s.components, sort_dicts=False)
{'H2O(aq)': 54.73448554291005,
 'Na[+1]': 0.787931002295781,
 'SO4[-2]': 0.28792619065639297,
 'NaSO4[-1]': 0.21206518590120618,
 'O2(aq)': 0.00020695543078971901,
 'CO2(aq)': 1.1146138376904539e-05,
 'HSO4[-1]': 8.623450159934477e-06,
 'HCO3[-1]': 6.485127634618242e-06,
 'NaHCO3(aq)': 3.231096476060681e-06,
 'H[+1]': 1.686023418612036e-06,
 'OH[-1]': 1.0440345163482693e-08,
 'CO3[-2]': 8.437470447581793e-10,
 'NaOH(aq)': 6.025696327809447e-10,
 'NaCO3[-1]': 3.784786810450528e-10,
 'H2SO4(aq)': 7.537485278010312e-15,
 'HSO5[-1]': 7.674126538281614e-27,
 'S2O8[-2]': 1.3569320589256627e-38,
 'H2C(aq)': 0.0,
 'H3C(aq)': 0.0,
 'CH4(aq)': 0.0,
 'CO(aq)': 0.0,
 'H2(aq)': 0.0,
 'H2S(aq)': 0.0,
 'H2SO3(aq)': 0.0,
 'HS[-1]': 0.0,
 'HS2O3[-1]': 0.0,
 'HSO3[-1]': 0.0,
 'S[-2]': 0.0,
 'S2[-2]': 0.0,
 'S2O3[-2]': 0.0,
 'SO2[-1]': 0.0,
 'S2O5[-2]': 0.0,
 'S2O6[-2]': 0.0,
 'S3[-2]': 0.0,
 'SO2[-0.66666667]': 0.0,
 'S4[-2]': 0.0,
 'S2O3[-1]': 0.0,
 'S5[-2]': 0.0,
 'S5O6[-2]': 0.0,
 'SO2(aq)': 0.0,
 'SO3[-2]': 0.0}
```

Some of these species have "unknown" oxidation states, causing further problems:
```
>>> s.get_saturation_index()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[13], line 1
----> 1 s.get_saturation_index()

File ~/miniforge3/envs/feynman/code/pyEQL/src/pyEQL/solution.py:2958, in Solution.get_saturation_index(self, get_plot)
   2956 if (engine.ppsol is None) or (self.components != engine._stored_comp):
   2957     engine._destroy_ppsol()
-> 2958     engine._setup_ppsol(self)
   2960 ppsol = engine.ppsol
   2962 phases = list(ppsol.phases.keys())

File ~/miniforge3/envs/feynman/code/pyEQL/src/pyEQL/engines.py:252, in Phreeqc2026EOS._setup_ppsol(self, solution)
    248 bare_el = el.split("(")[0]
    249 if bare_el in SPECIAL_ELEMENTS:
    250     # PHREEQC will ignore float-formatted oxi states. Need to make sure we are
    251     # passing, e.g. 'C(4)' and not 'C(4.0)'
--> 252     key = f"{bare_el}({int(float(el.split('(')[-1].split(')')[0]))})"
    253 elif bare_el in ["H", "O"]:
    254     continue

ValueError: could not convert string to float: 'unk'
```

### EDIT: additional bug fixed by this change

It turns out that the zero concentration solutes were the cause of #431 .