### PR TITLE
Fix ubuntu-24.04-arm wheel test failure (phreeqc engine)

### DIFF
--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -352,7 +352,7 @@ class Phreeqc2026EOS(EOS):
         if self.pp is None:
             # The PHREEQC backend failed to initialize on this platform (see the engine's
             # __init__). Honor the documented contract: equilibrate() has no effect.
-            logger.debug("PHREEQC backend unavailable; equilibrate() has no effect.")
+            logger.error("PHREEQC backend unavailable; equilibrate() has no effect.")
             return
         if self.ppsol is not None:
             self.ppsol.forget()

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -223,6 +223,15 @@ class Phreeqc2026EOS(EOS):
 
     def _setup_ppsol(self, solution: "solution.Solution") -> None:
         """Helper method to set up a Phreeqc solution for subsequent analysis."""
+        if self.pp is None:
+            # Backend unavailable (see the engine's __init__). Raise a clear, immediate error
+            # instead of crashing deep in the wrapper. Raising ValueError (rather than, e.g.,
+            # RuntimeError) lets get_activity_coefficient's caller catch it and fall back to
+            # unit activity coefficients, so property reads still work.
+            raise ValueError(
+                "The PHREEQC backend is unavailable on this platform, so this calculation "
+                "cannot be performed. See earlier log messages for details."
+            )
 
         self._stored_comp = solution.components.copy()
         solv_mass = solution.solvent_mass.to("kg").magnitude
@@ -340,6 +349,11 @@ class Phreeqc2026EOS(EOS):
                 {"CO2": "0.000316 atm"}
                 {"CO2": -3.5}
         """
+        if self.pp is None:
+            # The PHREEQC backend failed to initialize on this platform (see the engine's
+            # __init__). Honor the documented contract: equilibrate() has no effect.
+            logger.debug("PHREEQC backend unavailable; equilibrate() has no effect.")
+            return
         if self.ppsol is not None:
             self.ppsol.forget()
         self._setup_ppsol(solution)
@@ -586,15 +600,21 @@ class PhreeqcEOS(Phreeqc2026EOS):
         self.db_path = (
             Path(os.path.dirname(__file__)) / "database" if self.phreeqc_db in ["llnl.dat", "geothermal.dat"] else None
         )
-        # create the PhreeqcPython instance
-        # try/except added to catch unsupported architectures, such as Apple Silicon
+        # create the PhreeqPython instance
+        # try/except added to catch platforms with no compatible phreeqpython binary, such as
+        # Apple Silicon or aarch64 Linux (phreeqpython ships no arm64 Linux shared library)
         try:
             self.pp = PhreeqPython(database=self.phreeqc_db, database_directory=self.db_path)
         except OSError:
+            # super().__init__() already set self.pp to an in-tree Phreeqc wrapper, which is the
+            # wrong type for this (phreeqpython-backed) engine. Discard it and mark the backend
+            # unavailable so equilibrate() cleanly no-ops instead of crashing deep inside the
+            # wrapper. See equilibrate() and _setup_ppsol().
+            self.pp = None
             logger.error(
                 "OSError encountered when trying to instantiate phreeqpython. Most likely this means you"
-                " are running on an architecture that is not supported by PHREEQC, such as Apple M1/M2 chips."
-                " pyEQL will work, but equilibrate() will have no effect."
+                " are running on a platform with no compatible phreeqpython binary, such as Apple M1/M2"
+                " chips or aarch64 Linux. pyEQL will work, but equilibrate() will have no effect."
             )
         # attributes to hold the PhreeqPython solution.
         self.ppsol = None

--- a/tests/test_engine_phreeqc2026.py
+++ b/tests/test_engine_phreeqc2026.py
@@ -296,7 +296,7 @@ def test_equilibrate_water_pH7():
 def test_repeated_equilibrate():
     # repeated calls to equilibrate should not change the properties (much)
     for cb in [None, "pH", "auto"]:
-        s1 = Solution({}, pH=7.00, volume="1 L", engine="phreeqc", balance_charge=cb)
+        s1 = Solution({}, pH=7.00, volume="1 L", engine="phreeqc2026", balance_charge=cb)
         first_pH = s1.pH
         first_volume = s1.volume.magnitude
         first_mass = s1.mass.magnitude


### PR DESCRIPTION
## Summary

The v1.6.0 release wheel job [failed only on `ubuntu-24.04-arm`](https://github.com/KingsburyLab/pyEQL/actions/runs/30818366819/job/91741666869) while `ubuntu-latest` (x86_64) and `macos-latest` (arm64) built and tested cleanly.

**Root cause:** `test_repeated_equilibrate` (newly added since v1.5.0) lives in `tests/test_engine_phreeqc2026.py` — the file run inside the built wheel by cibuildwheel — but was the only test there using `engine="phreeqc"`, the legacy engine backed by the third-party **phreeqpython** package. phreeqpython ships native libraries for x86_64 Linux (`viphreeqc.so`), Windows (`.dll`), and macOS universal (`.dylib`, incl. arm64), but **no aarch64-Linux library**. So on `ubuntu-24.04-arm`, `PhreeqPython()` raises `OSError`, and `PhreeqcEOS` was left in a broken state that crashed with a confusing `ValueError: There is a problem with your input ... 'str' object has no attribute '_phreeqc'`.

This is why the other platforms pass: x86_64 Linux loads its `.so`, and macOS arm loads the universal `.dylib`.

## Changes

**1. `test(phreeqc)`** — `test_repeated_equilibrate` now uses `engine="phreeqc2026"` (the in-tree compiled engine), matching every other test in this file. This is the fix that turns the arm wheel job green; the `"phreeqc"` was a copy-paste slip.

**2. `fix(PhreeqcEOS)`** — make the engine degrade cleanly when the phreeqpython backend can't load, honoring the documented contract ("pyEQL will work, but equilibrate() will have no effect"):
- set `self.pp = None` in the `OSError` handler so state is well-defined (it had been left pointing at the wrong-typed in-tree wrapper inherited from `super().__init__()`);
- `equilibrate()` no-ops when `self.pp is None`;
- `_setup_ppsol()` raises a clear `ValueError` when `self.pp is None` — already caught by the activity-coefficient fallback, so property reads keep working;
- generalize the previously Apple-only diagnostic message to also mention aarch64 Linux.

The `PhreeqcEOS` OSError bug is pre-existing (identical at v1.5.0); the new test was simply the first to exercise it in the wheel build. Fix #2 does not change CI outcome — it just prevents the crash if anyone hits that path at runtime.

## Verification
- `tests/test_engine_phreeqc2026.py` → 20 passed (the wheel-tested file)
- `tests/test_engine_phreeqc.py` → 19 passed (real phreeqpython path, unaffected)
- Simulated the arm case (`engine.pp = None`): `equilibrate()` no-ops, `get_activity_coefficient` degrades to `1`, `_setup_ppsol` raises the legible `ValueError`

The new guards are inert for `engine="phreeqc2026"` (its `self.pp` is never `None`), so that engine is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)