### PR TITLE
Enable retrieving alkalinity from phreeqc2026 engine

### DIFF
--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -492,7 +492,6 @@ class Phreeqc2026EOS(EOS):
         # the only reason to re-adjust charge balance here is to account for any missing species.
         solution._adjust_charge_balance()
 
-        ### is it helpful to keep this? JJS 8/24/26
         # Sync _stored_comp to the final post-equilibration components so that subsequent property
         # calls (e.g., get_activity_coefficient) reuse this ppsol instead of triggering an
         # unnecessary rebuild.

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -143,9 +143,11 @@ class EOS(MSONable, ABC):
             ValueError if the calculation cannot be completed, e.g. due to insufficient number of parameters or lack of convergence.
         """
 
+    @abstractmethod
     def get_alkalinity(self, solution: "solution.Solution") -> ureg.Quantity | None:
-        """Return alkalinity in mg/L as CaCO3, or None if this engine does not support it."""
-        return None
+        """
+        Return alkalinity in mg/L as CaCO3, or None if this engine does not support it.
+        """
 
 
 class IdealEOS(EOS):
@@ -168,6 +170,9 @@ class IdealEOS(EOS):
     def get_solute_volume(self, solution: "solution.Solution") -> ureg.Quantity:
         """Return the volume of the solutes."""
         return ureg.Quantity(0, "L")
+
+    def get_alkalinity(self, solution: "solution.Solution") -> None:
+        return None
 
     def equilibrate(
         self,
@@ -559,16 +564,22 @@ class Phreeqc2026EOS(EOS):
         # TODO - see if we can access molar volume or solute volume via the pyEQL-phreeqc wrapper
         return ureg.Quantity(0, "L")
 
-    def get_alkalinity(self, solution: "solution.Solution") -> ureg.Quantity:
-        """Return alkalinity in mg/L as CaCO3 from PHREEQC's TOT('Alk') (eq/kgw)."""
-        if (self.ppsol is None) or (solution.components != self._stored_comp):
-            self._destroy_ppsol()
-            self._setup_ppsol(solution)
+    def get_alkalinity(self, solution: "solution.Solution") -> ureg.Quantity | None:
+        """
+        Return alkalinity in mg/L as CaCO3 from PHREEQC's ALK variable
+        (eq/kgw), or None on failure.
+        """
+        try:
+            if (self.ppsol is None) or (solution.components != self._stored_comp):
+                self._destroy_ppsol()
+                self._setup_ppsol(solution)
+        except ValueError:
+            return None
         alk_eq_per_kgw = self.ppsol.get_alkalinity()
         kgw = self.ppsol.get_kgw()
         vol_L = solution.volume.to("L").magnitude
         alk_eq_per_L = alk_eq_per_kgw * kgw / vol_L
-        return (ureg.Quantity(alk_eq_per_L, "eq/L") * EQUIV_WT_CACO3).to("mg/L")
+        return (ureg.Quantity(alk_eq_per_L, "mol/L") * EQUIV_WT_CACO3).to("mg/L")
 
     def __deepcopy__(self, memo) -> Self:
         # custom deepcopy required because the Phreeqc instance used by the Native and Phreeqc engines
@@ -667,13 +678,12 @@ class PhreeqcEOS(Phreeqc2026EOS):
         # TODO - find a way to access or calculate osmotic coefficient
         return ureg.Quantity(1, "dimensionless")
 
-    def get_alkalinity(self, solution: "solution.Solution") -> ureg.Quantity:
-        """Return alkalinity in mg/L as CaCO3 from phreeqpython's get_total_ion('Alk')."""
-        if (self.ppsol is None) or (solution.components != self._stored_comp):
-            self._destroy_ppsol()
-            self._setup_ppsol(solution)
-        alk_eq_per_L = self.ppsol.pp.ip.get_total_ion(self.ppsol.number, "Alk")
-        return (ureg.Quantity(alk_eq_per_L, "eq/L") * EQUIV_WT_CACO3).to("mg/L")
+    def get_alkalinity(self, solution: "solution.Solution") -> None:
+        # phreeqpython does not appear to expose PHREEQC's internal ALK
+        # variable; for now, fall back to the manual formula in
+        # pyEQL.Solution. Perhaps work with upstream phreeqpython code base. See
+        # https://github.com/Vitens/phreeqpython/issues/38 .
+        return None
 
     def __deepcopy__(self, memo) -> Self:
         # custom deepcopy required because the PhreeqPython instance used by the Native and Phreeqc engines

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -29,6 +29,8 @@ from pyEQL.utils import FormulaDict, standardize_formula
 # PHREEQC will ignore others (e.g., 'Na(1)')
 SPECIAL_ELEMENTS = ["S", "C", "N", "Cu", "Fe", "Mn"]
 
+EQUIV_WT_CACO3 = ureg.Quantity(100.09 / 2, "g/mol")
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -140,6 +142,10 @@ class EOS(MSONable, ABC):
         Raises:
             ValueError if the calculation cannot be completed, e.g. due to insufficient number of parameters or lack of convergence.
         """
+
+    def get_alkalinity(self, solution: "solution.Solution") -> ureg.Quantity | None:
+        """Return alkalinity in mg/L as CaCO3, or None if this engine does not support it."""
+        return None
 
 
 class IdealEOS(EOS):
@@ -553,6 +559,17 @@ class Phreeqc2026EOS(EOS):
         # TODO - see if we can access molar volume or solute volume via the pyEQL-phreeqc wrapper
         return ureg.Quantity(0, "L")
 
+    def get_alkalinity(self, solution: "solution.Solution") -> ureg.Quantity:
+        """Return alkalinity in mg/L as CaCO3 from PHREEQC's TOT('Alk') (eq/kgw)."""
+        if (self.ppsol is None) or (solution.components != self._stored_comp):
+            self._destroy_ppsol()
+            self._setup_ppsol(solution)
+        alk_eq_per_kgw = self.ppsol.get_alkalinity()
+        kgw = self.ppsol.get_kgw()
+        vol_L = solution.volume.to("L").magnitude
+        alk_eq_per_L = alk_eq_per_kgw * kgw / vol_L
+        return (ureg.Quantity(alk_eq_per_L, "eq/L") * EQUIV_WT_CACO3).to("mg/L")
+
     def __deepcopy__(self, memo) -> Self:
         # custom deepcopy required because the Phreeqc instance used by the Native and Phreeqc engines
         # is not pickle-able.
@@ -649,6 +666,14 @@ class PhreeqcEOS(Phreeqc2026EOS):
         """
         # TODO - find a way to access or calculate osmotic coefficient
         return ureg.Quantity(1, "dimensionless")
+
+    def get_alkalinity(self, solution: "solution.Solution") -> ureg.Quantity:
+        """Return alkalinity in mg/L as CaCO3 from phreeqpython's get_total_ion('Alk')."""
+        if (self.ppsol is None) or (solution.components != self._stored_comp):
+            self._destroy_ppsol()
+            self._setup_ppsol(solution)
+        alk_eq_per_L = self.ppsol.pp.ip.get_total_ion(self.ppsol.number, "Alk")
+        return (ureg.Quantity(alk_eq_per_L, "eq/L") * EQUIV_WT_CACO3).to("mg/L")
 
     def __deepcopy__(self, memo) -> Self:
         # custom deepcopy required because the PhreeqPython instance used by the Native and Phreeqc engines

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -141,6 +141,7 @@ class EOS(MSONable, ABC):
             ValueError if the calculation cannot be completed, e.g. due to insufficient number of parameters or lack of convergence.
         """
 
+
 class IdealEOS(EOS):
     """Ideal solution equation of state engine."""
 

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -29,8 +29,6 @@ from pyEQL.utils import FormulaDict, standardize_formula
 # PHREEQC will ignore others (e.g., 'Na(1)')
 SPECIAL_ELEMENTS = ["S", "C", "N", "Cu", "Fe", "Mn"]
 
-EQUIV_WT_CACO3 = ureg.Quantity(100.09 / 2, "g/mol")
-
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -143,13 +141,6 @@ class EOS(MSONable, ABC):
             ValueError if the calculation cannot be completed, e.g. due to insufficient number of parameters or lack of convergence.
         """
 
-    @abstractmethod
-    def get_alkalinity(self, solution: "solution.Solution") -> ureg.Quantity | None:
-        """
-        Return alkalinity in mg/L as CaCO3, or None if this engine does not support it.
-        """
-
-
 class IdealEOS(EOS):
     """Ideal solution equation of state engine."""
 
@@ -170,9 +161,6 @@ class IdealEOS(EOS):
     def get_solute_volume(self, solution: "solution.Solution") -> ureg.Quantity:
         """Return the volume of the solutes."""
         return ureg.Quantity(0, "L")
-
-    def get_alkalinity(self, solution: "solution.Solution") -> None:
-        return None
 
     def equilibrate(
         self,
@@ -504,6 +492,7 @@ class Phreeqc2026EOS(EOS):
         # the only reason to re-adjust charge balance here is to account for any missing species.
         solution._adjust_charge_balance()
 
+        ### is it helpful to keep this? JJS 8/24/26
         # Sync _stored_comp to the final post-equilibration components so that subsequent property
         # calls (e.g., get_activity_coefficient) reuse this ppsol instead of triggering an
         # unnecessary rebuild.
@@ -563,23 +552,6 @@ class Phreeqc2026EOS(EOS):
         """Return the volume of the solutes."""
         # TODO - see if we can access molar volume or solute volume via the pyEQL-phreeqc wrapper
         return ureg.Quantity(0, "L")
-
-    def get_alkalinity(self, solution: "solution.Solution") -> ureg.Quantity | None:
-        """
-        Return alkalinity in mg/L as CaCO3 from PHREEQC's ALK variable
-        (eq/kgw), or None on failure.
-        """
-        try:
-            if (self.ppsol is None) or (solution.components != self._stored_comp):
-                self._destroy_ppsol()
-                self._setup_ppsol(solution)
-        except ValueError:
-            return None
-        alk_eq_per_kgw = self.ppsol.get_alkalinity()
-        kgw = self.ppsol.get_kgw()
-        vol_L = solution.volume.to("L").magnitude
-        alk_eq_per_L = alk_eq_per_kgw * kgw / vol_L
-        return (ureg.Quantity(alk_eq_per_L, "mol/L") * EQUIV_WT_CACO3).to("mg/L")
 
     def __deepcopy__(self, memo) -> Self:
         # custom deepcopy required because the Phreeqc instance used by the Native and Phreeqc engines
@@ -677,13 +649,6 @@ class PhreeqcEOS(Phreeqc2026EOS):
         """
         # TODO - find a way to access or calculate osmotic coefficient
         return ureg.Quantity(1, "dimensionless")
-
-    def get_alkalinity(self, solution: "solution.Solution") -> None:
-        # phreeqpython does not appear to expose PHREEQC's internal ALK
-        # variable; for now, fall back to the manual formula in
-        # pyEQL.Solution. Perhaps work with upstream phreeqpython code base. See
-        # https://github.com/Vitens/phreeqpython/issues/38 .
-        return None
 
     def __deepcopy__(self, memo) -> Self:
         # custom deepcopy required because the PhreeqPython instance used by the Native and Phreeqc engines

--- a/src/pyEQL/phreeqc/core.py
+++ b/src/pyEQL/phreeqc/core.py
@@ -11,7 +11,7 @@ SOLUTION_PROPS = (
     "CELL_NO",
     "TOT['water']",
     "OSMOTIC",
-    "TOT['Alk']",
+    "ALK",
 )
 SPECIES_PROPS = ("MOL", "ACT", "DIFF_C")
 EQ_SPECIES_PROPS = ("SI",)

--- a/src/pyEQL/phreeqc/core.py
+++ b/src/pyEQL/phreeqc/core.py
@@ -11,6 +11,7 @@ SOLUTION_PROPS = (
     "CELL_NO",
     "TOT['water']",
     "OSMOTIC",
+    "TOT['Alk']",
 )
 SPECIES_PROPS = ("MOL", "ACT", "DIFF_C")
 EQ_SPECIES_PROPS = ("SI",)

--- a/src/pyEQL/phreeqc/solution.py
+++ b/src/pyEQL/phreeqc/solution.py
@@ -38,7 +38,7 @@ class PHRQSol:
 
     def get_alkalinity(self) -> float:
         """Return total alkalinity in eq/kgw as computed by PHREEQC."""
-        return self._get_calculated_prop("TOT['Alk']")
+        return self._get_calculated_prop("ALK")
 
     def get_osmotic_coefficient(self) -> float:
         return self._get_calculated_prop("OSMOTIC")

--- a/src/pyEQL/phreeqc/solution.py
+++ b/src/pyEQL/phreeqc/solution.py
@@ -36,6 +36,10 @@ class PHRQSol:
     def get_diffusion_coefficient(self, species) -> float:
         return self._get_calculated_prop("DIFF_C", species=species)
 
+    def get_alkalinity(self) -> float:
+        """Return total alkalinity in eq/kgw as computed by PHREEQC."""
+        return self._get_calculated_prop("TOT['Alk']")
+
     def get_osmotic_coefficient(self) -> float:
         return self._get_calculated_prop("OSMOTIC")
 

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -75,6 +75,7 @@ class Solution(MSONable):
         balance_charge: str | None = None,
         solvent: str | list = "H2O",
         engine: EOS | Literal["native", "ideal", "phreeqc", "phreeqc2026"] = "native",
+        alkalinity_calc: Literal["pyEQL", "engine"] = "pyEQL", # TODO: add docstring if keep
         database: str | Path | Store | None = None,
         default_diffusion_coeff: float = 1.6106e-9,
         log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] | None = "ERROR",
@@ -238,6 +239,8 @@ class Solution(MSONable):
         # PHREEQC ppsol build, which reads _cb_species, before that determination runs).
         self._cb_species = None
 
+        self.alkalinity_calc = alkalinity_calc
+        
         # instantiate a water substance for property retrieval
         self.water_substance = create_water_substance(self.temperature, self.pressure)
         """IAPWS instance describing water properties."""
@@ -898,9 +901,16 @@ class Solution(MSONable):
             .. [stm] Stumm, Werner and Morgan, James J. Aquatic Chemistry, 3rd ed, pp 165. Wiley Interscience, 1996.
 
         """
-        engine_alk = self.engine.get_alkalinity(self)
-        if engine_alk is not None:
-            return engine_alk
+
+        if self.alkalinity_calc == "engine":
+            engine_alk = self.engine.get_alkalinity(self)
+            if engine_alk is not None:
+                return engine_alk
+            else:
+                print("here")
+                warnings.warn("The selected engine does not provide alkalinity "
+                              "directly. Switching to pyEQL's calculation.")
+                self.alkalinity_calc = "pyEQL"
 
         alkalinity = 0 * ureg.mol / ureg.L
 

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -898,6 +898,10 @@ class Solution(MSONable):
             .. [stm] Stumm, Werner and Morgan, James J. Aquatic Chemistry, 3rd ed, pp 165. Wiley Interscience, 1996.
 
         """
+        engine_alk = self.engine.get_alkalinity(self)
+        if engine_alk is not None:
+            return engine_alk
+
         alkalinity = 0 * ureg.mol / ureg.L
 
         # Conservative cations (Group I and II), keyed by element with their characteristic charge.

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -981,24 +981,23 @@ class Solution(MSONable):
         alk_mgL = (alkalinity * EQUIV_WT_CACO3).to("mg/L")
 
         # check against alkalinity provided by the engine
-        try:
-            if (self.engine.ppsol is None) or (self.components != self.engine._stored_comp):
-                self.engine._destroy_ppsol()
-                self.engine._setup_ppsol(self)
-            alk_eq_per_kgw = self.engine.ppsol.get_alkalinity()
-            kgw = self.engine.ppsol.get_kgw()
-            vol_L = self.volume.to("L").magnitude
-            alk_eq_per_L = alk_eq_per_kgw * kgw / vol_L
-            engine_alk = (ureg.Quantity(alk_eq_per_L, "mol/L") * EQUIV_WT_CACO3).to("mg/L")
-        except (ValueError, AttributeError):
-            engine_alk = None
-        if engine_alk is not None:
-            frac_alk_dif = np.abs(1 - engine_alk/alk_mgL)
-            #print(frac_alk_dif)
-            if frac_alk_dif > 0.01:
-                warnings.warn(f"Alkalinity calculated by the {self._engine} engine ({engine_alk}) is more than 1% different than alkalinity calculated by pyEQL")
+        if hasattr(self.engine, 'ppsol'):
+            try:
+                if (self.engine.ppsol is None) or (self.components\
+                                                   != self.engine._stored_comp):
+                    self.engine._destroy_ppsol()
+                    self.engine._setup_ppsol(self)
+                alk_eq_per_kgw = self.engine.ppsol.get_alkalinity()
+                kgw = self.engine.ppsol.get_kgw()
+                vol_L = self.volume.to("L").magnitude
+                alk_eq_per_L = alk_eq_per_kgw * kgw / vol_L
+                engine_alk = alk_eq_per_L * EQUIV_WT_CACO3.magnitude * 1000
+            except ValueError:
+                engine_alk = None
+            if engine_alk is not None:
+                if not np.isclose(engine_alk, alk_mgL.magnitude, rtol=0.01):
+                    self.logger.warning(f"Alkalinity calculated by the {self._engine} engine ({engine_alk}) is more than 1% different than alkalinity calculated by pyEQL")
              
-        #return (alkalinity * EQUIV_WT_CACO3).to("mg/L")
         return alk_mgL
 
     @property

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -75,7 +75,6 @@ class Solution(MSONable):
         balance_charge: str | None = None,
         solvent: str | list = "H2O",
         engine: EOS | Literal["native", "ideal", "phreeqc", "phreeqc2026"] = "native",
-        alkalinity_calc: Literal["pyEQL", "engine"] = "pyEQL", # TODO: add docstring if keep
         database: str | Path | Store | None = None,
         default_diffusion_coeff: float = 1.6106e-9,
         log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] | None = "ERROR",
@@ -239,8 +238,6 @@ class Solution(MSONable):
         # PHREEQC ppsol build, which reads _cb_species, before that determination runs).
         self._cb_species = None
 
-        self.alkalinity_calc = alkalinity_calc
-        
         # instantiate a water substance for property retrieval
         self.water_substance = create_water_substance(self.temperature, self.pressure)
         """IAPWS instance describing water properties."""
@@ -902,16 +899,6 @@ class Solution(MSONable):
 
         """
 
-        if self.alkalinity_calc == "engine":
-            engine_alk = self.engine.get_alkalinity(self)
-            if engine_alk is not None:
-                return engine_alk
-            else:
-                print("here")
-                warnings.warn("The selected engine does not provide alkalinity "
-                              "directly. Switching to pyEQL's calculation.")
-                self.alkalinity_calc = "pyEQL"
-
         alkalinity = 0 * ureg.mol / ureg.L
 
         # Conservative cations (Group I and II), keyed by element with their characteristic charge.
@@ -991,7 +978,28 @@ class Solution(MSONable):
                 if item in weak_species:
                     alkalinity += self.get_amount(item, "eq/L") * (-1)
 
-        return (alkalinity * EQUIV_WT_CACO3).to("mg/L")
+        alk_mgL = (alkalinity * EQUIV_WT_CACO3).to("mg/L")
+
+        # check against alkalinity provided by the engine
+        try:
+            if (self.engine.ppsol is None) or (self.components != self.engine._stored_comp):
+                self.engine._destroy_ppsol()
+                self.engine._setup_ppsol(self)
+            alk_eq_per_kgw = self.engine.ppsol.get_alkalinity()
+            kgw = self.engine.ppsol.get_kgw()
+            vol_L = self.volume.to("L").magnitude
+            alk_eq_per_L = alk_eq_per_kgw * kgw / vol_L
+            engine_alk = (ureg.Quantity(alk_eq_per_L, "mol/L") * EQUIV_WT_CACO3).to("mg/L")
+        except (ValueError, AttributeError):
+            engine_alk = None
+        if engine_alk is not None:
+            frac_alk_dif = np.abs(1 - engine_alk/alk_mgL)
+            #print(frac_alk_dif)
+            if frac_alk_dif > 0.01:
+                warnings.warn(f"Alkalinity calculated by the {self._engine} engine ({engine_alk}) is more than 1% different than alkalinity calculated by pyEQL")
+             
+        #return (alkalinity * EQUIV_WT_CACO3).to("mg/L")
+        return alk_mgL
 
     @property
     def hardness(self) -> Quantity:

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -418,21 +418,26 @@ def test_water_stability_reducing(s8, caplog):
 
 def test_alkalinity_hardness(s3, s5, s6, s9, s10):
     assert np.isclose(s3.hardness, 0)
-    assert np.isclose(s3.alkalinity.magnitude, 0, atol=0.01)  # PHREEQC returns a tiny floating-point residual for NaCl
+    assert np.isclose(s3.alkalinity, 0)
 
-    # PHREEQC's ALK is the proton-condition alkalinity (based on speciated weak-acid/base species),
-    # which differs from the Stumm & Morgan conservative-species charge-balance approach used previously.
-    assert np.isclose(s5.alkalinity.magnitude, 41.165, rtol=0.01)
+    assert np.isclose(s5.alkalinity.magnitude, 100, rtol=0.005)
     assert np.isclose(s5.hardness.magnitude, 100, rtol=0.005)
 
-    assert np.isclose(s6.alkalinity.magnitude, 258.22, rtol=0.01)
+    assert np.isclose(s6.alkalinity.magnitude, -5900, rtol=0.005)
     assert np.isclose(s6.hardness.magnitude, 600, rtol=0.005)
 
-    assert np.isclose(s9.alkalinity.magnitude, 78.742, rtol=0.01)
+    assert np.isclose(s9.alkalinity.magnitude, 100.09, rtol=0.005)
     assert np.isclose(s9.hardness.magnitude, 0, rtol=0.005)
 
-    assert np.isclose(s10.alkalinity.magnitude, -5.254, rtol=0.01, atol=0.1)
+    assert np.isclose(s10.alkalinity.magnitude, 150.135, rtol=0.005)
     assert np.isclose(s10.hardness.magnitude, 100.09, rtol=0.005)
+
+
+def test_alkalinity_engine_warning(caplog):
+    s = Solution.from_preset("seawater")
+    with caplog.at_level(logging.WARNING, logger=s.logger.name):
+        s.alkalinity
+    assert any("is more than 1% different than alkalinity calculated by pyEQL" in m for m in caplog.messages)
 
 
 def test_pressure_temperature(s5):

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -418,18 +418,20 @@ def test_water_stability_reducing(s8, caplog):
 
 def test_alkalinity_hardness(s3, s5, s6, s9, s10):
     assert np.isclose(s3.hardness, 0)
-    assert np.isclose(s3.alkalinity, 0)
+    assert np.isclose(s3.alkalinity.magnitude, 0, atol=0.01)  # PHREEQC returns a tiny floating-point residual for NaCl
 
-    assert np.isclose(s5.alkalinity.magnitude, 100, rtol=0.005)
+    # PHREEQC's ALK is the proton-condition alkalinity (based on speciated weak-acid/base species),
+    # which differs from the Stumm & Morgan conservative-species charge-balance approach used previously.
+    assert np.isclose(s5.alkalinity.magnitude, 41.165, rtol=0.01)
     assert np.isclose(s5.hardness.magnitude, 100, rtol=0.005)
 
-    assert np.isclose(s6.alkalinity.magnitude, -5900, rtol=0.005)
+    assert np.isclose(s6.alkalinity.magnitude, 258.22, rtol=0.01)
     assert np.isclose(s6.hardness.magnitude, 600, rtol=0.005)
 
-    assert np.isclose(s9.alkalinity.magnitude, 100.09, rtol=0.005)
+    assert np.isclose(s9.alkalinity.magnitude, 78.742, rtol=0.01)
     assert np.isclose(s9.hardness.magnitude, 0, rtol=0.005)
 
-    assert np.isclose(s10.alkalinity.magnitude, 150.135, rtol=0.005)
+    assert np.isclose(s10.alkalinity.magnitude, -5.254, rtol=0.01, atol=0.1)
     assert np.isclose(s10.hardness.magnitude, 100.09, rtol=0.005)
 
 


### PR DESCRIPTION
## Summary

Major changes:

- creates infrastructure for `Solution.engine.get_alkalinity()`
- retrieve alkalinity for the `phreeqc2026` engine
- use the engine's alkalinity, if available; otherwise fall-back to alkalinity calculated within pyEQL class

## Todos

- review overall approach
- determine whether the changed test conditions are generally appropriate
- also fix pyEQL's alkalinity calculation(?) see #458 

## Checklist

- [ ] Google format doc strings added.
- [ ] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [ ] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.
<!-- - [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) -->

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
