### PR TITLE
Fix scalar * and / mutating the Solution in place (fixes #457)

### DIFF
--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -14,7 +14,7 @@ import warnings
 from functools import lru_cache
 from importlib.resources import files
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 import numpy as np
 from maggma.stores import JSONStore, Store
@@ -2925,18 +2925,43 @@ class Solution(MSONable):
     def __sub__(self, other: Solution) -> None:
         raise NotImplementedError("Subtraction of solutions is not implemented.")
 
-    def __mul__(self, factor: float) -> None:
+    def __mul__(self, factor: float) -> Solution:
         """
-        Solution multiplication: scale all components by a factor. For example, Solution * 2 will double the moles of
-        every component (including solvent). No other properties will change.
+        Solution multiplication: return a new Solution with all components scaled by a factor. For example,
+        Solution * 2 returns a new Solution with double the moles of every component (including solvent). No other
+        properties change, and the original Solution is left unmodified. Use ``*=`` to scale in place.
+        """
+        new_sol = self.from_dict(self.as_dict())
+        new_sol.volume *= factor
+        return new_sol
+
+    def __rmul__(self, factor: float) -> Solution:
+        """Scalar multiplication is commutative: ``factor * Solution`` is equivalent to ``Solution * factor``."""
+        return self.__mul__(factor)
+
+    def __truediv__(self, factor: float) -> Solution:
+        """
+        Solution division: return a new Solution with all components scaled by a factor. For example,
+        Solution / 2 returns a new Solution with half the moles of every component (including solvent). No other
+        properties change, and the original Solution is left unmodified. Use ``/=`` to scale in place.
+        """
+        new_sol = self.from_dict(self.as_dict())
+        new_sol.volume /= factor
+        return new_sol
+
+    def __imul__(self, factor: float) -> Self:
+        """
+        In-place solution multiplication: scale all components of this Solution by a factor. For example,
+        Solution *= 2 doubles the moles of every component (including solvent) in place. No other properties change.
         """
         self.volume *= factor
         return self
 
-    def __truediv__(self, factor: float) -> None:
+    def __itruediv__(self, factor: float) -> Self:
         """
-        Solution division: scale all components by a factor. For example, Solution / 2 will remove half of the moles
-        of every compoonents (including solvent). No other properties will change.
+        In-place solution division: scale all components of this Solution by a factor. For example,
+        Solution /= 2 removes half of the moles of every component (including solvent) in place. No other properties
+        change.
         """
         self.volume /= factor
         return self

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -842,6 +842,58 @@ def test_arithmetic_and_copy(s2, s6):
         s2 + s_bad
 
 
+def test_multiplication_returns_new_solution(s6):
+    """Standalone `*` / `/` return a new scaled Solution and leave the original unchanged (issue #457).
+
+    In-place `*=` / `/=` keep mutating the original, consistent with the documented scaling behavior.
+    """
+    # access .volume first so any pending volume update is applied and the flag cleared, making the
+    # "original is unchanged" comparisons below exact
+    orig_volume = s6.volume.to("L").magnitude
+    orig_components = copy.deepcopy(dict(s6.components))
+
+    # standalone multiplication returns a NEW object and does not mutate the original
+    doubled = s6 * 2
+    assert doubled is not s6
+    assert isinstance(doubled, Solution)
+    assert np.isclose(s6.volume.to("L").magnitude, orig_volume)
+    for solute, amt in orig_components.items():
+        assert np.isclose(s6.components[solute], amt)
+
+    # the returned Solution is scaled by the factor: 2x volume and 2x moles of every component
+    assert np.isclose(doubled.volume.to("L").magnitude, 2 * orig_volume)
+    for solute, amt in orig_components.items():
+        assert np.isclose(doubled.components[solute], 2 * amt)
+
+    # scalar multiplication is commutative (rmul)
+    r_doubled = 2 * s6
+    assert r_doubled is not s6
+    assert np.isclose(r_doubled.volume.to("L").magnitude, 2 * orig_volume)
+    assert np.isclose(s6.volume.to("L").magnitude, orig_volume)
+
+    # standalone division returns a NEW object and does not mutate the original
+    halved = s6 / 2
+    assert halved is not s6
+    assert np.isclose(s6.volume.to("L").magnitude, orig_volume)
+    assert np.isclose(halved.volume.to("L").magnitude, orig_volume / 2)
+    for solute, amt in orig_components.items():
+        assert np.isclose(halved.components[solute], amt / 2)
+
+    # in-place operators STILL mutate self and return self
+    s6_ref = s6
+    s6 *= 3
+    assert s6 is s6_ref
+    assert np.isclose(s6.volume.to("L").magnitude, 3 * orig_volume)
+    for solute, amt in orig_components.items():
+        assert np.isclose(s6.components[solute], 3 * amt)
+
+    s6 /= 3
+    assert s6 is s6_ref
+    assert np.isclose(s6.volume.to("L").magnitude, orig_volume)
+    for solute, amt in orig_components.items():
+        assert np.isclose(s6.components[solute], amt)
+
+
 def test_from_dict_complex():
     """
     Test the behavior of as/from dict with a solution containing multiple solutes, that is


### PR DESCRIPTION
Fixes #457.

## Problem
Standalone `sol * factor` and `sol / factor` mutated the original Solution and returned the same object. Root cause: `__mul__`/`__truediv__` did `self.volume *= factor; return self`, and the `volume` setter rescales every component in place -- so `sol * 2` doubled `sol`'s volume and moles and returned an alias (`(sol * 2) is sol` was `True`), instead of a new scaled Solution. Reported by @jjstickel.

## Fix
- `__mul__` / `__truediv__` now return a **new** scaled Solution, built via the existing faithful `from_dict(as_dict(...))` round-trip and then scaling the copy's volume; the original is left unchanged.
- `__imul__` / `__itruediv__` are added to preserve the documented **in-place** `*=` / `/=` scaling behavior (mutate self, return self).
- `__rmul__` is added so `factor * sol` works (commutativity).

This makes `*` and `/` consistent with Python numeric-type semantics, as @rkingsbury requested in the issue thread, while keeping the documented in-place `*=` / `/=` behavior intact.

## Tests
- New `test_multiplication_returns_new_solution`: asserts `sol * 2 is not sol`, the original is unchanged, the returned Solution has 2x volume/moles, `2 * sol` works (rmul), `sol / 2` returns a new halved Solution, and `sol *= 3` / `sol /= 3` still mutate in place and return self.
- Verified red -> green (pre-fix the new test fails at `assert doubled is not sol`) and the full `tests/test_solution.py` suite passes with no regressions (`test_arithmetic_and_copy` included).

---
This contribution was prepared with AI assistance and reviewed by me before submission.