### PR TITLE
Fix alkalinity of speciated solutions (seawater/PHREEQC too high) (#458)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `Solution.alkalinity` is now invariant to how the equilibrium engine speciates the solution. The
+  conservative-ion contributions are computed from the *total analytical* concentration of each
+  constituent (via `get_total_amount`) rather than from free-ion concentrations. Previously, engines
+  such as PHREEQC that form ion pairs (e.g. `NaSO4[-1]`, `MgSO4(aq)`, `CaSO4(aq)`) would reduce the
+  free `SO4[-2]` concentration during `equilibrate()`, spuriously inflating the alkalinity of
+  seawater from ~117 to ~753 mg/L as CaCO3. (#458, @rkingsbury)
+
 ## [1.6.1] - 2026-08-04
 
 ### Fixed

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -887,34 +887,48 @@ class Solution(MSONable):
 
             The summation should extend over all weak inorganic species that can participate in acid-base reactions. In this method, we consider HCO3[-1], CO3[-2], H2PO4[-1], HPO4[-2], PO4[-3], HS[-1], S[-2], H3SiO4[-1], H2SiO4[-2], B(OH)4[-1], NH3(aq), OH[-1], and H[+1] as the relevant weak acid/base species, while organics are excluded.
 
+            The conservative contributions are computed from the *total analytical* concentration of
+            each constituent (via :meth:`get_el_amt_dict`) rather than from the free-ion concentration.
+            This is important for engines that speciate the solution into ion pairs and complexes
+            (e.g. PHREEQC, which forms NaSO4[-1], MgSO4(aq), CaSO4(aq), etc. in seawater). Alkalinity is
+            a conservative quantity that must be unaffected by such re-speciation; using free-ion
+            concentrations would spuriously change it after equilibration (see issue #458).
+
         References:
             .. [stm] Stumm, Werner and Morgan, James J. Aquatic Chemistry, 3rd ed, pp 165. Wiley Interscience, 1996.
 
         """
         alkalinity = 0 * ureg.mol / ureg.L
 
+        # Conservative cations (Group I and II), keyed by element with their characteristic charge.
+        # These elements exist in a single oxidation state, so their total (over all oxidation states)
+        # is used.
         base_cations = {
-            "Li[+1]",
-            "Na[+1]",
-            "K[+1]",
-            "Rb[+1]",
-            "Cs[+1]",
-            "Fr[+1]",
-            "Be[+2]",
-            "Mg[+2]",
-            "Ca[+2]",
-            "Sr[+2]",
-            "Ba[+2]",
-            "Ra[+2]",
+            "Li": 1,
+            "Na": 1,
+            "K": 1,
+            "Rb": 1,
+            "Cs": 1,
+            "Fr": 1,
+            "Be": 2,
+            "Mg": 2,
+            "Ca": 2,
+            "Sr": 2,
+            "Ba": 2,
+            "Ra": 2,
         }
+        # Strong-acid anions, keyed by (element, oxidation state) with their characteristic charge.
+        # The oxidation state distinguishes the conservative species from weak/reduced forms of the
+        # same element (e.g. sulfate S(6) vs. sulfide, nitrate N(5) vs. ammonia, chloride Cl(-1) vs.
+        # chlorate/perchlorate).
         acid_anions = {
-            "Cl[-1]",
-            "Br[-1]",
-            "I[-1]",
-            "SO4[-2]",
-            "NO3[-1]",
-            "ClO4[-1]",
-            "ClO3[-1]",
+            ("Cl", -1.0): -1,
+            ("Br", -1.0): -1,
+            ("I", -1.0): -1,
+            ("S", 6.0): -2,
+            ("N", 5.0): -1,
+            ("Cl", 7.0): -1,
+            ("Cl", 5.0): -1,
         }
 
         weak_species = {
@@ -933,17 +947,35 @@ class Solution(MSONable):
             "H[+1]",
         }  # Note that organics are excluded
 
-        conservative_species = base_cations.union(acid_anions)
-        # check presence of conservative cations or strong base anions
-        conservative_def = any(item in conservative_species for item in self.components)
+        # Total (analytical) moles of every element, broken down by oxidation state, computed in a
+        # single pass. Using totals rather than free-ion concentrations keeps alkalinity invariant to
+        # how the engine speciates the solution (e.g. ion pairing).
+        el_amt = self.get_el_amt_dict(nested=True)  # {element: {oxi_state: moles}}
 
-        for item in self.components:
-            if item in conservative_species:
-                # Conservative cations and strong base anions
-                alkalinity += self.get_amount(item, "eq/L")
-            elif item in weak_species and not conservative_def:
-                # Weak acid/base species, exclude organics
-                alkalinity += self.get_amount(item, "eq/L") * (-1)
+        # Sum the charge-weighted total concentration of each conservative constituent present.
+        conservative_eq = 0.0  # equivalents (mol of charge), signed
+        conservative_def = False
+        for element, charge in base_cations.items():
+            by_oxi_state = el_amt.get(element)
+            if by_oxi_state:
+                conservative_def = True
+                conservative_eq += charge * sum(by_oxi_state.values())
+        for (element, oxi_state), charge in acid_anions.items():
+            moles = (el_amt.get(element) or {}).get(oxi_state)
+            if moles:
+                conservative_def = True
+                conservative_eq += charge * moles
+
+        if conservative_def:
+            # Conservative cations and strong-acid anions are present
+            alkalinity = conservative_eq * ureg.mol / self.volume
+        else:
+            # No conservative species present, so use the weak acid/base definition. These species
+            # participate directly in acid-base equilibria, so their (speciated) concentrations are
+            # the correct basis.
+            for item in self.components:
+                if item in weak_species:
+                    alkalinity += self.get_amount(item, "eq/L") * (-1)
 
         return (alkalinity * EQUIV_WT_CACO3).to("mg/L")
 

--- a/tests/test_engine_phreeqc2026.py
+++ b/tests/test_engine_phreeqc2026.py
@@ -436,6 +436,31 @@ def test_alkalinity():
     assert solution.alkalinity.magnitude == pytest.approx(calculated_alk_mg_L, abs=1e-8)
 
 
+def test_alkalinity_conservative_after_equilibrate():
+    """Regression test for issue #458.
+
+    Alkalinity computed from the conservative-ion definition must be invariant to how the engine
+    speciates the solution. Previously it was calculated from *free* ion concentrations, so when
+    PHREEQC formed ion pairs during equilibration (e.g. NaSO4[-1], MgSO4(aq), CaSO4(aq)), the free
+    SO4[-2] concentration dropped and the (subtracted) sulfate term shrank, spuriously inflating the
+    seawater alkalinity from ~117 to ~753 mg/L as CaCO3. Computing the conservative terms from total
+    (analytical) concentrations keeps alkalinity essentially unchanged across equilibration.
+    """
+    sol = Solution.from_preset("seawater", engine="phreeqc2026", balance_charge="pH")
+    alk_before = sol.alkalinity.to("mg/L").magnitude
+
+    # Seawater alkalinity from conservative ions is on the order of 100-120 mg/L as CaCO3
+    assert 100 < alk_before < 130
+
+    sol.equilibrate(atmosphere=True)
+    alk_after = sol.alkalinity.to("mg/L").magnitude
+
+    # Alkalinity is conservative: equilibrating with the atmosphere (adding a small amount of CO2)
+    # should barely change it, and must not jump by several hundred mg/L as it did before the fix.
+    assert alk_after == pytest.approx(alk_before, rel=0.05)
+    assert alk_after < 130
+
+
 def test_equilibrate_2L():
     solution = Solution({"Cu+2": "1 umol/L", "O-2": "1 umol/L"}, volume="2 L", engine="phreeqc2026")
     solution.equilibrate(atmosphere=True)


### PR DESCRIPTION
Fixes #458.

## Root cause

`Solution.alkalinity` computes the conservative-ion definition

> Alk = Σ zᵢ·C(conservative cations) + Σ zᵢ·C(strong-acid anions)

but it summed over **free, speciated** ion concentrations (`get_amount(item, "eq/L")`). With the default/ideal engine each conservative element exists as a single free ion, so free = total and the result is correct. The PHREEQC engines, however, speciate the solution into ion pairs and complexes during `equilibrate()` — in seawater `NaSO4[-1]`, `MgSO4(aq)`, `CaSO4(aq)`, `Mg(SO4)2[-2]`, `KSO4[-1]`, etc. This pulls sulfate out of the free `SO4[-2]` bucket:

| ion (signed eq/L) | before eq | after eq | Δ |
|---|---|---|---|
| **SO4[-2]** | **−0.05585** | **−0.01843** | **+0.03743** |
| Na[+1] | 0.46384 | 0.45406 | −0.00979 |
| Mg[+2] | 0.10448 | 0.09520 | −0.00928 |
| Cl[-1] | −0.53991 | −0.54426 | −0.00435 |
| Ca[+2] | 0.02034 | 0.01917 | −0.00117 |

Free `SO4[-2]` drops from ~0.028 to ~0.009 M. Because sulfate is a **subtracted** term, its disappearance adds ~+0.037 eq/L ≈ **+630 mg/L as CaCO₃**, which is essentially the entire reported jump from **117 → 753 mg/L**.

## Fix

Alkalinity is a conservative quantity and must be invariant to how the engine speciates the solution. The conservative cation/anion terms are now computed from the **total analytical** concentration of each constituent, multiplied by the constituent's characteristic charge. Oxidation state keeps the strong-acid anions distinct from weak/reduced forms of the same element (sulfate `S(6)` vs. sulfide, nitrate `N(5)` vs. ammonia, chloride `Cl(-1)` vs. chlorate/perchlorate). The weak-acid-species fallback (used when no conservative ions are present) is unchanged, since those species participate directly in acid–base equilibria and their speciated concentrations are the correct basis.

The totals are obtained in a **single pass** via `get_el_amt_dict(nested=True)` rather than one `get_total_amount()` call per constituent (each of which rebuilds `get_components_by_element()` and re-scans the component list). On a 47-species equilibrated seawater solution this reduces `Solution.alkalinity` from **~16.7 ms to ~0.28 ms per call (~60×)**, with byte-for-byte identical results.

### Verification

| | current (free-ion) | fixed (totals) |
|---|---|---|
| before `equilibrate` | 117.44 | 117.44 |
| after `equilibrate(atmosphere=True)` | **753.35** (bug) | **118.38** |

The totals-based value matches the old value exactly before equilibration (no regression for the ideal engine) and stays stable afterward (the small residual change is the added atmospheric CO₂).

## Tests

- Adds `test_alkalinity_conservative_after_equilibrate` (regression for #458): seawater alkalinity stays within 5% and below 130 mg/L across `equilibrate(atmosphere=True)`.
- Full `test_solution.py`, `test_engine_phreeqc2026.py`, and `test_engine_phreeqc.py` suites pass (784 tests), including the existing `test_alkalinity_hardness` and weak-acid `test_alkalinity` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
