### PR TITLE
sync _stored_comp after equilibrate to avoid redundant ppsol rebuilds

### DIFF
--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -493,6 +493,11 @@ class Phreeqc2026EOS(EOS):
         # the only reason to re-adjust charge balance here is to account for any missing species.
         solution._adjust_charge_balance()
 
+        # Sync _stored_comp to the final post-equilibration components so that subsequent property
+        # calls (e.g., get_activity_coefficient) reuse this ppsol instead of triggering an
+        # unnecessary rebuild.
+        self._stored_comp = solution.components.copy()
+
         # set the volume update flag so that the volume will be consistent with the new composition.
         solution.volume_update_required = True
 


### PR DESCRIPTION
## Summary

After equilibrate() updates solution.components, `_stored_comp` held a pre-equilibration snapshot, causing every subsequent property call (get_activity_coefficient, etc.) to unnecessarily rebuild ppsol.

## Checklist

- [ ] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.
<!-- - [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) -->
